### PR TITLE
Configure machine dependencies via options

### DIFF
--- a/cmd/firectl/main.go
+++ b/cmd/firectl/main.go
@@ -21,15 +21,10 @@ import (
 	"strconv"
 	"strings"
 
-	firecracker "github.com/firecracker-microvm/go-firecracker"
-	flags "github.com/jessevdk/go-flags"
+	"github.com/firecracker-microvm/go-firecracker"
+	"github.com/jessevdk/go-flags"
 	log "github.com/sirupsen/logrus"
 )
-
-func validateDriveEntry(entry string) error {
-
-	return nil
-}
 
 func checkConfig(cfg firecracker.Config) error {
 	var err error
@@ -216,8 +211,7 @@ func main() {
 		log.Fatalf("Configuration error: %s", err)
 	}
 
-	fireracker := firecracker.NewFirecrackerClient(fcCfg.SocketPath)
-	m := firecracker.NewMachine(fcCfg, fireracker, logger)
+	m := firecracker.NewMachine(fcCfg, firecracker.WithLogger(logger))
 
 	ctx := context.Background()
 	vmmCtx, vmmCancel := context.WithCancel(ctx)

--- a/machine_test.go
+++ b/machine_test.go
@@ -39,7 +39,7 @@ func init() {
 
 // Ensure that we can create a new machine
 func TestNewMachine(t *testing.T) {
-	m := NewMachine(Config{}, NewFirecrackerClient(""), nil)
+	m := NewMachine(Config{})
 	if m == nil {
 		t.Errorf("NewMachine did not create a Machine")
 	}
@@ -63,7 +63,7 @@ func TestMicroVMExecution(t *testing.T) {
 		CPUTemplate: cpuTemplate,
 		MemInMiB:    memSz,
 	}
-	m := NewMachine(cfg, NewFirecrackerClient(cfg.SocketPath), nil)
+	m := NewMachine(cfg)
 	ctx := context.Background()
 	vmmCtx, vmmCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer vmmCancel()
@@ -97,7 +97,7 @@ func TestStartVMM(t *testing.T) {
 		SocketPath: filepath.Join("fc-start-vmm-test.sock"),
 		BinPath:    getFirecrackerBinaryPath(),
 	}
-	m := NewMachine(cfg, NewFirecrackerClient(cfg.SocketPath), nil)
+	m := NewMachine(cfg)
 	timeout, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 	defer cancel()
 	errchan, err := m.startVMM(timeout)

--- a/opts.go
+++ b/opts.go
@@ -1,0 +1,19 @@
+package firecracker
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+type Opt func(*Machine)
+
+func WithClient(client Firecracker) Opt {
+	return func(machine *Machine) {
+		machine.client = client
+	}
+}
+
+func WithLogger(logger *logrus.Logger) Opt {
+	return func(machine *Machine) {
+		machine.logger = logger
+	}
+}


### PR DESCRIPTION
*Description of changes:*
A bit better way to pass dependencies to machine SDK, so we don't have to create firecracker client every time while still can mock dependencies for testing

FYI @samuelkarp @nmeyerhans 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
