### PR TITLE
Add a missing copyright header

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -1,3 +1,16 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package firecracker
 
 import (


### PR DESCRIPTION
Found a go source file that didn't have a copyright header. Fixed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
