### PR TITLE
Trace HTTP requests to Firecracker in debug mode

### DIFF
--- a/cmd/firectl/main.go
+++ b/cmd/firectl/main.go
@@ -204,6 +204,7 @@ func main() {
 		CPUTemplate:       firecracker.CPUTemplate(opts.FcCPUTemplate),
 		HtEnabled:         !opts.FcDisableHt,
 		MemInMiB:          opts.FcMemSz,
+		Debug:             opts.Debug,
 	}
 
 	err = checkConfig(fcCfg)
@@ -211,7 +212,7 @@ func main() {
 		log.Fatalf("Configuration error: %s", err)
 	}
 
-	m := firecracker.NewMachine(fcCfg, firecracker.WithLogger(logger))
+	m := firecracker.NewMachine(fcCfg, firecracker.WithLogger(log.NewEntry(logger)))
 
 	ctx := context.Background()
 	vmmCtx, vmmCancel := context.WithCancel(ctx)

--- a/firecracker.go
+++ b/firecracker.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/go-openapi/strfmt"
 
 	"github.com/firecracker-microvm/firecracker-go-sdk/client"
@@ -33,7 +34,7 @@ type FirecrackerClient struct {
 	client *client.Firecracker
 }
 
-func NewFirecrackerClient(socketPath string) *FirecrackerClient {
+func NewFirecrackerClient(socketPath string, logger *logrus.Entry, debug bool) *FirecrackerClient {
 	httpClient := client.NewHTTPClient(strfmt.NewFormats())
 
 	socketTransport := &http.Transport{
@@ -49,6 +50,15 @@ func NewFirecrackerClient(socketPath string) *FirecrackerClient {
 
 	transport := httptransport.New(client.DefaultHost, client.DefaultBasePath, client.DefaultSchemes)
 	transport.Transport = socketTransport
+
+	if debug {
+		transport.SetDebug(debug)
+	}
+
+	if logger != nil {
+		transport.SetLogger(logger)
+	}
+
 	httpClient.SetTransport(transport)
 
 	return &FirecrackerClient{client: httpClient}

--- a/machine.go
+++ b/machine.go
@@ -80,6 +80,7 @@ type Config struct {
 	NetworkInterfaces []NetworkInterface
 	VsockDevices      []VsockDevice
 	Console           string
+	Debug             bool
 	machineCfg        models.MachineConfiguration
 }
 
@@ -143,11 +144,17 @@ func NewMachine(cfg Config, opts ...Opt) *Machine {
 	}
 
 	if m.logger == nil {
-		m.logger = log.NewEntry(log.New())
+		logger := log.New()
+
+		if cfg.Debug {
+			logger.SetLevel(log.DebugLevel)
+		}
+
+		m.logger = log.NewEntry(logger)
 	}
 
 	if m.client == nil {
-		m.client = NewFirecrackerClient(cfg.SocketPath)
+		m.client = NewFirecrackerClient(cfg.SocketPath, m.logger, cfg.Debug)
 	}
 
 	m.logger.Debug("Called NewMachine()")

--- a/machine_test.go
+++ b/machine_test.go
@@ -39,7 +39,7 @@ func init() {
 
 // Ensure that we can create a new machine
 func TestNewMachine(t *testing.T) {
-	m := NewMachine(Config{})
+	m := NewMachine(Config{Debug: true})
 	if m == nil {
 		t.Errorf("NewMachine did not create a Machine")
 	}
@@ -62,6 +62,7 @@ func TestMicroVMExecution(t *testing.T) {
 		CPUCount:    nCpus,
 		CPUTemplate: cpuTemplate,
 		MemInMiB:    memSz,
+		Debug:       true,
 	}
 	m := NewMachine(cfg)
 	ctx := context.Background()


### PR DESCRIPTION
*Description of changes:*
This allows to see HTTP requests/responses logs from/to Firecracker in debug mode. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
