### PR TITLE
Add Metadata support

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -13,17 +13,18 @@ You need some external resources in order to run the tests, as described below:
 1. A firecracker binary (tested with 0.10.1), but any recent version should
    work.  Must either be installed as `./firecracker` or the path must be
    specified through the `FC_TEST_BIN` environment variable.
-2. Access to hardware virtualization via `/dev/kvm` (ensure you have mode
+2. Access to hardware virtualization via `/dev/kvm` and `/dev/vhost-vsock` (ensure you have mode
    `+rw`!)
 3. An uncompressed Linux kernel binary that can boot in Firecracker VM (Must be
-   installed as `./vmlinux`)
+   installed as `./testdata/vmlinux`)
 4. A tap device owned by your userid (Must be either named `fc-test-tap0` or
    have the name specified with the `FC_TEST_TAP` environment variable; try
    `sudo ip tuntap add fc-test-tap0 mode tap user $UID` to create `fc-test-tap0`
    if you need to create one)
-5. A root filesystem image installed (Must be named `root-drive.img`; can be
+5. A root filesystem image installed (Must be named `testdata/root-drive.img`)
+6. A secondary device image (Must be named `testdata/drive-2.img`; can be
    empty, create it something like
-   `dd if=/dev/zero of=drive-2.img bs=1k count=102400`)
+   `dd if=/dev/zero of=testdata/drive-2.img bs=1k count=102400`)
 
 With all of those set up, `make test EXTRAGOARGS=-v` should create a Firecracker
 process and run the Linux kernel in a MicroVM.

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ EXTRAGOARGS:=
 
 all: build
 
-build clean test:
+generate build clean test:
 	go $@ $(EXTRAGOARGS)
 	for d in $(SUBDIRS); do \
 		cd $$d && go $@ $(EXTRAGOARGS); \
 	done
 
-.PHONY: all clean build test
+.PHONY: all generate clean build test

--- a/client/models/error.go
+++ b/client/models/error.go
@@ -29,7 +29,7 @@ import (
 type Error struct {
 
 	// A description of the error condition
-	FaultMessage string `json:"faultMessage,omitempty"`
+	FaultMessage string `json:"fault_message,omitempty"`
 }
 
 // Validate validates this error

--- a/client/operations/operations_client.go
+++ b/client/operations/operations_client.go
@@ -126,7 +126,7 @@ func (a *Client) PatchMmds(params *PatchMmdsParams) (*PatchMmdsNoContent, error)
 /*
 PutMmds creates a m m d s microvm metadata service data store
 */
-func (a *Client) PutMmds(params *PutMmdsParams) (*PutMmdsNoContent, error) {
+func (a *Client) PutMmds(params *PutMmdsParams) (*PutMmdsCreated, *PutMmdsNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutMmdsParams()
@@ -145,9 +145,15 @@ func (a *Client) PutMmds(params *PutMmdsParams) (*PutMmdsNoContent, error) {
 		Client:             params.HTTPClient,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return result.(*PutMmdsNoContent), nil
+	switch value := result.(type) {
+	case *PutMmdsCreated:
+		return value, nil, nil
+	case *PutMmdsNoContent:
+		return nil, value, nil
+	}
+	return nil, nil, nil
 
 }
 

--- a/client/operations/put_mmds_responses.go
+++ b/client/operations/put_mmds_responses.go
@@ -38,6 +38,13 @@ type PutMmdsReader struct {
 func (o *PutMmdsReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 
+	case 201:
+		result := NewPutMmdsCreated()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
+
 	case 204:
 		result := NewPutMmdsNoContent()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -64,6 +71,27 @@ func (o *PutMmdsReader) ReadResponse(response runtime.ClientResponse, consumer r
 	}
 }
 
+// NewPutMmdsCreated creates a PutMmdsCreated with default headers values
+func NewPutMmdsCreated() *PutMmdsCreated {
+	return &PutMmdsCreated{}
+}
+
+/*PutMmdsCreated handles this case with default header values.
+
+MMDS data store created
+*/
+type PutMmdsCreated struct {
+}
+
+func (o *PutMmdsCreated) Error() string {
+	return fmt.Sprintf("[PUT /mmds][%d] putMmdsCreated ", 201)
+}
+
+func (o *PutMmdsCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
 // NewPutMmdsNoContent creates a PutMmdsNoContent with default headers values
 func NewPutMmdsNoContent() *PutMmdsNoContent {
 	return &PutMmdsNoContent{}
@@ -71,7 +99,7 @@ func NewPutMmdsNoContent() *PutMmdsNoContent {
 
 /*PutMmdsNoContent handles this case with default header values.
 
-MMDS data store created/updated.
+MMDS data store updated.
 */
 type PutMmdsNoContent struct {
 }

--- a/client/swagger.yaml
+++ b/client/swagger.yaml
@@ -257,8 +257,10 @@ paths:
           schema:
             type: object
       responses:
+        201:
+          description: MMDS data store created
         204:
-          description: MMDS data store created/updated.
+          description: MMDS data store updated.
         400:
           description: MMDS data store cannot be created due to bad input.
           schema:
@@ -393,7 +395,7 @@ definitions:
 
   Error:
     properties:
-      faultMessage:
+      fault_message:
         type: string
         description: A description of the error condition
 

--- a/firecracker.go
+++ b/firecracker.go
@@ -132,6 +132,14 @@ func (f *FirecrackerClient) CreateSyncAction(ctx context.Context, info *models.I
 	return f.client.Operations.CreateSyncAction(params)
 }
 
+func (f *FirecrackerClient) PutMmds(ctx context.Context, metadata interface{}) (*ops.PutMmdsCreated, *ops.PutMmdsNoContent, error) {
+	params := ops.NewPutMmdsParams()
+	params.SetContext(ctx)
+	params.SetBody(metadata)
+
+	return f.client.Operations.PutMmds(params)
+}
+
 func (f *FirecrackerClient) GetMachineConfig() (*ops.GetMachineConfigOK, error) {
 	p := ops.NewGetMachineConfigParams()
 	p.SetTimeout(firecrackerRequestTimeout)

--- a/machine_mock_test.go
+++ b/machine_mock_test.go
@@ -140,6 +140,20 @@ func (mr *MockFirecrackerMockRecorder) CreateSyncAction(ctx, info interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSyncAction", reflect.TypeOf((*MockFirecracker)(nil).CreateSyncAction), ctx, info)
 }
 
+// PutMmds mocks base method
+func (m *MockFirecracker) PutMmds(ctx context.Context, metadata interface{}) (*operations.PutMmdsCreated, *operations.PutMmdsNoContent, error) {
+	ret := m.ctrl.Call(m, "PutMmds", ctx, metadata)
+	ret0, _ := ret[0].(*operations.PutMmdsCreated)
+	ret1, _ := ret[1].(*operations.PutMmdsNoContent)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PutMmds indicates an expected call of PutMmds
+func (mr *MockFirecrackerMockRecorder) PutMmds(ctx, metadata interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutMmds", reflect.TypeOf((*MockFirecracker)(nil).PutMmds), ctx, metadata)
+}
+
 // GetMachineConfig mocks base method
 func (m *MockFirecracker) GetMachineConfig() (*operations.GetMachineConfigOK, error) {
 	ret := m.ctrl.Call(m, "GetMachineConfig")
@@ -152,3 +166,4 @@ func (m *MockFirecracker) GetMachineConfig() (*operations.GetMachineConfigOK, er
 func (mr *MockFirecrackerMockRecorder) GetMachineConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineConfig", reflect.TypeOf((*MockFirecracker)(nil).GetMachineConfig))
 }
+

--- a/machine_test.go
+++ b/machine_test.go
@@ -108,7 +108,9 @@ func TestMicroVMExecution(t *testing.T) {
 	t.Run("TestAttachRootDrive", func(t *testing.T) { testAttachRootDrive(ctx, t, m) })
 	t.Run("TestAttachSecondaryDrive", func(t *testing.T) { testAttachSecondaryDrive(ctx, t, m) })
 	t.Run("TestAttachVsock", func(t *testing.T) { testAttachVsock(ctx, t, m) })
+	t.Run("SetMetadata", func(t *testing.T) { testSetMetadata(ctx, t, m) })
 	t.Run("TestStartInstance", func(t *testing.T) { testStartInstance(vmmCtx, t, m) })
+
 	// Let the VMM start and stabilize...
 	time.Sleep(5 * time.Second)
 	t.Run("TestStopVMM", func(t *testing.T) { testStopVMM(ctx, t, m) })
@@ -305,3 +307,12 @@ func TestWaitForSocket(t *testing.T) {
 		t.Error("waitForSocket did not properly detect program exit")
 	}
 }
+
+func testSetMetadata(ctx context.Context, t *testing.T, m *Machine) {
+	metadata := map[string]string{"key": "value"}
+	err := m.SetMetadata(ctx, metadata)
+	if err != nil {
+		t.Errorf("failed to set metadata: %s", err)
+	}
+}
+


### PR DESCRIPTION
*Issue #:* #12

*Description of changes:*
* Adding metadata support in the api & cli
* Added allow mmds to network card (automatically set to enabled in cli if metadata provided)
* Added a test in machine_test.go and tested manually. made sure test pass with `make test`
* Added `make generate` target for convenience and update HACKING.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
