### PR TITLE
adding fifo logging files and refactoring the SDK

### DIFF
--- a/cmd/firectl/main.go
+++ b/cmd/firectl/main.go
@@ -18,11 +18,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/firecracker-microvm/firecracker-go-sdk"
+	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
 	"github.com/jessevdk/go-flags"
 	log "github.com/sirupsen/logrus"
 )
@@ -43,28 +47,37 @@ const (
 	executableMask = 0111
 )
 
-func parseBlockDevices(entries []string) ([]firecracker.BlockDevice, error) {
-	var devices []firecracker.BlockDevice
-	for _, entry := range entries {
-		var path string
+func parseBlockDevices(entries []string) ([]models.Drive, error) {
+	devices := []models.Drive{}
+
+	for i, entry := range entries {
+		path := ""
+		readOnly := true
+
 		if strings.HasSuffix(entry, ":rw") {
+			readOnly = false
 			path = strings.TrimSuffix(entry, ":rw")
 		} else if strings.HasSuffix(entry, ":ro") {
 			path = strings.TrimSuffix(entry, ":ro")
 		} else {
 			msg := fmt.Sprintf("Invalid drive specification. Must have :rw or :ro suffix")
-			return []firecracker.BlockDevice{}, errors.New(msg)
+			return nil, errors.New(msg)
 		}
+
 		if path == "" {
 			return nil, errors.New("Invalid drive specification")
 		}
-		_, err := os.Stat(path)
-		if err != nil {
+
+		if _, err := os.Stat(path); err != nil {
 			return nil, err
 		}
-		e := firecracker.BlockDevice{
-			HostPath: path,
-			Mode:     "rw",
+
+		e := models.Drive{
+			// i + 2 represents the drive ID. We will reserve 1 for root.
+			DriveID:      firecracker.String(strconv.Itoa(i + 2)),
+			PathOnHost:   firecracker.String(path),
+			IsReadOnly:   firecracker.Bool(readOnly),
+			IsRootDevice: firecracker.Bool(false),
 		}
 		devices = append(devices, e)
 	}
@@ -105,6 +118,76 @@ func parseVsocks(devices []string) ([]firecracker.VsockDevice, error) {
 	return result, nil
 }
 
+func createFifoFileLogs(fifoPath string) (*os.File, error) {
+	return os.OpenFile(fifoPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+}
+
+// handleFifos will see if any fifos need to be generated and if a fifo log
+// file should be created.
+func handleFifos(opts *options) (io.Writer, []func() error, error) {
+	// these booleans are used to check whether or not the fifo queue or metrics
+	// fifo queue needs to be generated. If any which need to be generated, then
+	// we know we need to create a temporary directory. Otherwise, a temporary
+	// directory does not need to be created.
+	generateFifoFilename := false
+	generateMetricFifoFilename := false
+	cleanupFns := []func() error{}
+	var err error
+
+	var fifo io.WriteCloser
+	if len(opts.FcFifoLogFile) > 0 {
+		if len(opts.FcLogFifo) > 0 {
+			return nil, cleanupFns, fmt.Errorf("vmm-log-fifo and firecracker-log cannot be used together")
+		}
+
+		generateFifoFilename = true
+		// if a fifo log file was specified via the CLI then we need to check if
+		// metric fifo was also specified. If not, we will then generate that fifo
+		if len(opts.FcMetricsFifo) == 0 {
+			generateMetricFifoFilename = true
+		}
+
+		if fifo, err = createFifoFileLogs(opts.FcFifoLogFile); err != nil {
+			return fifo, cleanupFns, fmt.Errorf("Failed to create fifo log file: %v", err)
+		}
+
+		cleanupFns = append(cleanupFns, func() error {
+			return fifo.Close()
+		})
+	} else if len(opts.FcLogFifo) > 0 || len(opts.FcMetricsFifo) > 0 {
+		// this checks to see if either one of the fifos was set. If at least one
+		// has been set we check to see if any of the others were not set. If one
+		// isn't set, we will generate the proper file path.
+		if len(opts.FcLogFifo) == 0 {
+			generateFifoFilename = true
+		}
+
+		if len(opts.FcMetricsFifo) == 0 {
+			generateMetricFifoFilename = true
+		}
+	}
+
+	if generateFifoFilename || generateMetricFifoFilename {
+		dir, err := ioutil.TempDir(os.TempDir(), "fcfifo")
+		if err != nil {
+			return fifo, cleanupFns, fmt.Errorf("Fail to create temporary directory: %v", err)
+		}
+
+		cleanupFns = append(cleanupFns, func() error {
+			return os.RemoveAll(dir)
+		})
+		if generateFifoFilename {
+			opts.FcLogFifo = filepath.Join(dir, "fc_fifo")
+		}
+
+		if generateMetricFifoFilename {
+			opts.FcMetricsFifo = filepath.Join(dir, "fc_metrics_fifo")
+		}
+	}
+
+	return fifo, cleanupFns, nil
+}
+
 type options struct {
 	FcBinary           string   `long:"firecracker-binary" description:"Path to firecracker binary"`
 	FcKernelImage      string   `long:"kernel" description:"Path to the kernel image" default:"./vmlinux"`
@@ -117,12 +200,12 @@ type options struct {
 	FcLogFifo          string   `long:"vmm-log-fifo" description:"FIFO for firecracker logs"`
 	FcLogLevel         string   `long:"log-level" description:"vmm log level" default:"Debug"`
 	FcMetricsFifo      string   `long:"metrics-fifo" description:"FIFO for firecracker metrics"`
-	FcCaptureFifoLogs  bool     `long:"capture-fifo-logs" description:"pipes fifo and metric fifo's contents to files"`
 	FcDisableHt        bool     `long:"disable-hyperthreading" short:"t" description:"Disable CPU Hyperthreading"`
 	FcCPUCount         int64    `long:"ncpus" short:"c" description:"Number of CPUs" default:"1"`
 	FcCPUTemplate      string   `long:"cpu-template" description:"Firecracker CPU Template (C3 or T2)"`
 	FcMemSz            int64    `long:"memory" short:"m" description:"VM memory, in MiB" default:"512"`
 	FcMetadata         string   `long:"metadata" description:"Firecracker Meatadata for MMDS (json)"`
+	FcFifoLogFile      string   `long:"firecracker-log" short:"l" description:"pipes the fifo contents to the specified file"`
 	Debug              bool     `long:"debug" short:"d" description:"Enable debug output"`
 	Help               bool     `long:"help" short:"h" description:"Show usage"`
 }
@@ -165,7 +248,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Unable to parse NIC config: %s", err)
 		} else {
-			log.Printf("Adding tap device %s", tapDev)
+			log.Error("Adding tap device %s", tapDev)
 			allowMDDS := metadata != nil
 			NICs = []firecracker.NetworkInterface{
 				firecracker.NetworkInterface{
@@ -177,36 +260,57 @@ func main() {
 		}
 	}
 
-	rootDrive := firecracker.BlockDevice{HostPath: opts.FcRootDrivePath, Mode: "rw"}
-
 	blockDevices, err := parseBlockDevices(opts.FcAdditionalDrives)
 	if err != nil {
 		log.Fatalf("Invalid block device specification: %s", err)
 	}
+
+	rootDrive := models.Drive{
+		DriveID:      firecracker.String("1"),
+		PathOnHost:   &opts.FcRootDrivePath,
+		IsRootDevice: firecracker.Bool(true),
+		IsReadOnly:   firecracker.Bool(false),
+		Partuuid:     opts.FcRootPartUUID,
+	}
+	blockDevices = append(blockDevices, rootDrive)
 
 	vsocks, err := parseVsocks(opts.FcVsockDevices)
 	if err != nil {
 		log.Fatalf("Invalid vsock specification: %s", err)
 	}
 
+	fifo, cleanFns, err := handleFifos(&opts)
+	// we call cleanup first due to errors returning at different points which
+	// may result in a file handle being opened.
+	defer func() {
+		for _, fn := range cleanFns {
+			if err := fn(); err != nil {
+				log.WithError(err).Error("Failed to cleanup")
+			}
+		}
+	}()
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
 	fcCfg := firecracker.Config{
-		SocketPath:            "./firecracker.sock",
-		LogFifo:               opts.FcLogFifo,
-		LogLevel:              opts.FcLogLevel,
-		MetricsFifo:           opts.FcMetricsFifo,
-		CaptureFifoLogsToFile: opts.FcCaptureFifoLogs,
-		KernelImagePath:       opts.FcKernelImage,
-		KernelArgs:            opts.FcKernelCmdLine,
-		RootDrive:             rootDrive,
-		RootPartitionUUID:     opts.FcRootPartUUID,
-		AdditionalDrives:      blockDevices,
-		NetworkInterfaces:     NICs,
-		VsockDevices:          vsocks,
-		CPUCount:              opts.FcCPUCount,
-		CPUTemplate:           firecracker.CPUTemplate(opts.FcCPUTemplate),
-		HtEnabled:             !opts.FcDisableHt,
-		MemInMiB:              opts.FcMemSz,
-		Debug:                 opts.Debug,
+		SocketPath:        "./firecracker.sock",
+		LogFifo:           opts.FcLogFifo,
+		LogLevel:          opts.FcLogLevel,
+		MetricsFifo:       opts.FcMetricsFifo,
+		FifoLogWriter:     fifo,
+		KernelImagePath:   opts.FcKernelImage,
+		KernelArgs:        opts.FcKernelCmdLine,
+		Drives:            blockDevices,
+		NetworkInterfaces: NICs,
+		VsockDevices:      vsocks,
+		MachineCfg: models.MachineConfiguration{
+			VcpuCount:   opts.FcCPUCount,
+			CPUTemplate: models.CPUTemplate(opts.FcCPUTemplate),
+			HtEnabled:   !opts.FcDisableHt,
+			MemSizeMib:  opts.FcMemSz,
+		},
+		Debug: opts.Debug,
 	}
 
 	if len(os.Args) == 1 {
@@ -249,29 +353,23 @@ func main() {
 		machineOpts = append(machineOpts, firecracker.WithProcessRunner(cmd))
 	}
 
-	m, err := firecracker.NewMachine(fcCfg, machineOpts...)
+	m, err := firecracker.NewMachine(vmmCtx, fcCfg, machineOpts...)
 	if err != nil {
 		log.Fatalf("Failed creating machine: %s", err)
 	}
 
-	if err := m.Init(vmmCtx); err != nil {
-		log.Fatalf("Firecracker Init returned error %s", err)
-	}
-
 	if metadata != nil {
-		err := m.SetMetadata(vmmCtx, metadata)
-		if err != nil {
-			log.Fatalf("Firecracker SetMetadata returned error %s", err)
-		}
+		m.EnableMetadata(metadata)
 	}
 
-	if err := m.StartInstance(vmmCtx); err != nil {
-		log.Fatalf("Failed to start instance: %v", err)
+	if err := m.Start(vmmCtx); err != nil {
+		log.Fatalf("Failed to start machine: %v", err)
 	}
+	defer m.StopVMM()
 
 	// wait for the VMM to exit
-	if err := <-m.ErrCh; err != nil {
-		log.Fatalf("startVMM returned error %s", err)
+	if err := m.Wait(vmmCtx); err != nil {
+		log.Fatalf("Wait returned an error %s", err)
 	}
-	log.Printf("startVMM was happy")
+	log.Printf("Start machine was happy")
 }

--- a/handlers.go
+++ b/handlers.go
@@ -1,0 +1,153 @@
+package firecracker
+
+import (
+	"context"
+	"fmt"
+)
+
+// Handler name constants
+const (
+	StartVMMHandlerName                = "StartVMM"
+	BootstrapLoggingHandlerName        = "BootstrapLogging"
+	CreateMachineHandlerName           = "CreateMachine"
+	CreateBootSourceHandlerName        = "CreateBootSource"
+	AttachDrivesHandlerName            = "AttachDrives"
+	CreateNetworkInterfacesHandlerName = "CreateNetworkInterfaces"
+	AddVsocksHandlerName               = "AddVsocks"
+)
+
+// StartVMMNamedHandler .
+var StartVMMNamedHandler = NamedHandler{
+	Name: StartVMMHandlerName,
+	Fn: func(ctx context.Context, m *Machine) error {
+		m.logger.Debugf(fmt.Sprintf("%s handler executing", StartVMMHandlerName))
+		return m.startVMM(ctx)
+	},
+}
+
+// BootstrapLoggingNamedHandler .
+var BootstrapLoggingNamedHandler = NamedHandler{
+	Name: BootstrapLoggingHandlerName,
+	Fn: func(ctx context.Context, m *Machine) error {
+		m.logger.Debugf(fmt.Sprintf("%s handler executing", BootstrapLoggingHandlerName))
+		if err := m.setupLogging(ctx); err != nil {
+			m.logger.Warnf("setupLogging() returned %s. Continuing anyway.", err)
+		} else {
+			m.logger.Debugf("back from setupLogging")
+		}
+
+		return nil
+	},
+}
+
+// CreateMachineNamedHandler .
+var CreateMachineNamedHandler = NamedHandler{
+	Name: CreateMachineHandlerName,
+	Fn: func(ctx context.Context, m *Machine) error {
+		m.logger.Debugf(fmt.Sprintf("%s handler executing", CreateMachineHandlerName))
+		return m.createMachine(ctx)
+	},
+}
+
+// CreateBootSourceNamedHandler .
+var CreateBootSourceNamedHandler = NamedHandler{
+	Name: CreateBootSourceHandlerName,
+	Fn: func(ctx context.Context, m *Machine) error {
+		m.logger.Debugf(fmt.Sprintf("%s handler executing", CreateBootSourceHandlerName))
+		return m.createBootSource(ctx, m.cfg.KernelImagePath, m.cfg.KernelArgs)
+	},
+}
+
+// AttachDrivesNamedHandler .
+var AttachDrivesNamedHandler = NamedHandler{
+	Name: AttachDrivesHandlerName,
+	Fn: func(ctx context.Context, m *Machine) error {
+		m.logger.Debugf(fmt.Sprintf("%s handler executing", AttachDrivesHandlerName))
+		drives := append([]BlockDevice{m.cfg.RootDrive}, m.cfg.AdditionalDrives...)
+		rootIndex := 0
+
+		return m.attachDrives(ctx, rootIndex, drives...)
+	},
+}
+
+// CreateNetworkInterfacesNamedHandler .
+var CreateNetworkInterfacesNamedHandler = NamedHandler{
+	Name: CreateNetworkInterfacesHandlerName,
+	Fn: func(ctx context.Context, m *Machine) error {
+		m.logger.Debugf(fmt.Sprintf("%s handler executing", CreateNetworkInterfacesHandlerName))
+		return m.createNetworkInterfaces(ctx, m.cfg.NetworkInterfaces...)
+	},
+}
+
+// AddVsocksNamedHandler .
+var AddVsocksNamedHandler = NamedHandler{
+	Name: AddVsocksHandlerName,
+	Fn: func(ctx context.Context, m *Machine) error {
+		m.logger.Debugf(fmt.Sprintf("%s handler executing", AddVsocksHandlerName))
+		return m.addVsocks(ctx, m.cfg.VsockDevices...)
+	},
+}
+
+var defaultHandlerList = HandlerList{}.Append(
+	StartVMMNamedHandler,
+	BootstrapLoggingNamedHandler,
+	CreateMachineNamedHandler,
+	CreateBootSourceNamedHandler,
+	AttachDrivesNamedHandler,
+	CreateNetworkInterfacesNamedHandler,
+	AddVsocksNamedHandler,
+)
+
+// HandlerList represents a list of named handler that
+// can be used to execute a flow of instructions for a given
+// machine.
+type HandlerList struct {
+	list []NamedHandler
+}
+
+// Append will append a new handler to the handler list.
+func (l HandlerList) Append(handlers ...NamedHandler) HandlerList {
+	l.list = append(l.list, handlers...)
+
+	return l
+}
+
+// Remove will return an updated handler with all instances
+// of the specific named handler being removed.
+func (l HandlerList) Remove(name string) HandlerList {
+	newList := HandlerList{}
+	for _, h := range l.list {
+		if h.Name != name {
+			newList.list = append(newList.list, h)
+		}
+	}
+
+	return newList
+}
+
+// Clear clears the whole list of handlers
+func (l HandlerList) Clear() HandlerList {
+	l.list = l.list[0:0]
+	return l
+}
+
+// NamedHandler represents a named handler that contains a
+// name and a function which is used to execute during
+// the initialization process of a machine.
+type NamedHandler struct {
+	Name string
+	Fn   func(context.Context, *Machine) error
+}
+
+// Run will execute each instruction in the handler list. If an
+// error occurs in any of the handlers, then the list will halt
+// execution and return the error.
+func (l HandlerList) Run(ctx context.Context, m *Machine) error {
+	for _, handler := range l.list {
+		if err := handler.Fn(ctx, m); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/handlers.go
+++ b/handlers.go
@@ -2,118 +2,210 @@ package firecracker
 
 import (
 	"context"
-	"fmt"
 )
 
 // Handler name constants
 const (
-	StartVMMHandlerName                = "StartVMM"
-	BootstrapLoggingHandlerName        = "BootstrapLogging"
-	CreateMachineHandlerName           = "CreateMachine"
-	CreateBootSourceHandlerName        = "CreateBootSource"
-	AttachDrivesHandlerName            = "AttachDrives"
-	CreateNetworkInterfacesHandlerName = "CreateNetworkInterfaces"
-	AddVsocksHandlerName               = "AddVsocks"
+	StartVMMHandlerName                = "fcinit.StartVMM"
+	BootstrapLoggingHandlerName        = "fcinit.BootstrapLogging"
+	CreateMachineHandlerName           = "fcinit.CreateMachine"
+	CreateBootSourceHandlerName        = "fcinit.CreateBootSource"
+	AttachDrivesHandlerName            = "fcinit.AttachDrives"
+	CreateNetworkInterfacesHandlerName = "fcinit.CreateNetworkInterfaces"
+	AddVsocksHandlerName               = "fcinit.AddVsocks"
+	SetMetadataHandlerName             = "fcinit.SetMetadata"
+
+	ValidateCfgHandlerName = "validate.Cfg"
 )
 
-// StartVMMNamedHandler .
-var StartVMMNamedHandler = NamedHandler{
+// StartVMMHandler is a named handler that will handle starting of the VMM.
+// This handler will also set the exit channel on completion.
+var StartVMMHandler = Handler{
 	Name: StartVMMHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		m.logger.Debugf(fmt.Sprintf("%s handler executing", StartVMMHandlerName))
 		return m.startVMM(ctx)
 	},
 }
 
-// BootstrapLoggingNamedHandler .
-var BootstrapLoggingNamedHandler = NamedHandler{
+// BootstrapLoggingHandler is a named handler that will set up fifo logging of
+// firecracker process.
+var BootstrapLoggingHandler = Handler{
 	Name: BootstrapLoggingHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		m.logger.Debugf(fmt.Sprintf("%s handler executing", BootstrapLoggingHandlerName))
 		if err := m.setupLogging(ctx); err != nil {
 			m.logger.Warnf("setupLogging() returned %s. Continuing anyway.", err)
 		} else {
-			m.logger.Debugf("back from setupLogging")
+			m.logger.Debugf("setup logging: success")
 		}
 
 		return nil
 	},
 }
 
-// CreateMachineNamedHandler .
-var CreateMachineNamedHandler = NamedHandler{
+// CreateMachineHandler is a named handler that will "create" the machine and
+// upload any necessary configuration to the firecracker process.
+var CreateMachineHandler = Handler{
 	Name: CreateMachineHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		m.logger.Debugf(fmt.Sprintf("%s handler executing", CreateMachineHandlerName))
 		return m.createMachine(ctx)
 	},
 }
 
-// CreateBootSourceNamedHandler .
-var CreateBootSourceNamedHandler = NamedHandler{
+// CreateBootSourceHandler is a named handler that will set up the booting
+// process of the firecracker process.
+var CreateBootSourceHandler = Handler{
 	Name: CreateBootSourceHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		m.logger.Debugf(fmt.Sprintf("%s handler executing", CreateBootSourceHandlerName))
 		return m.createBootSource(ctx, m.cfg.KernelImagePath, m.cfg.KernelArgs)
 	},
 }
 
-// AttachDrivesNamedHandler .
-var AttachDrivesNamedHandler = NamedHandler{
+// AttachDrivesHandler is a named handler that will attach all drives for the
+// firecracker process.
+var AttachDrivesHandler = Handler{
 	Name: AttachDrivesHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		m.logger.Debugf(fmt.Sprintf("%s handler executing", AttachDrivesHandlerName))
-		drives := append([]BlockDevice{m.cfg.RootDrive}, m.cfg.AdditionalDrives...)
-		rootIndex := 0
-
-		return m.attachDrives(ctx, rootIndex, drives...)
+		return m.attachDrives(ctx, m.cfg.Drives...)
 	},
 }
 
-// CreateNetworkInterfacesNamedHandler .
-var CreateNetworkInterfacesNamedHandler = NamedHandler{
+// CreateNetworkInterfacesHandler is a named handler that sets up network
+// interfaces to the firecracker process.
+var CreateNetworkInterfacesHandler = Handler{
 	Name: CreateNetworkInterfacesHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		m.logger.Debugf(fmt.Sprintf("%s handler executing", CreateNetworkInterfacesHandlerName))
 		return m.createNetworkInterfaces(ctx, m.cfg.NetworkInterfaces...)
 	},
 }
 
-// AddVsocksNamedHandler .
-var AddVsocksNamedHandler = NamedHandler{
+// AddVsocksHandler is a named handler that adds vsocks to the firecracker
+// process.
+var AddVsocksHandler = Handler{
 	Name: AddVsocksHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		m.logger.Debugf(fmt.Sprintf("%s handler executing", AddVsocksHandlerName))
 		return m.addVsocks(ctx, m.cfg.VsockDevices...)
 	},
 }
 
-var defaultHandlerList = HandlerList{}.Append(
-	StartVMMNamedHandler,
-	BootstrapLoggingNamedHandler,
-	CreateMachineNamedHandler,
-	CreateBootSourceNamedHandler,
-	AttachDrivesNamedHandler,
-	CreateNetworkInterfacesNamedHandler,
-	AddVsocksNamedHandler,
+// NewSetMetadataHandler is a named handler that puts the metadata into the
+// firecracker process.
+func NewSetMetadataHandler(metadata interface{}) Handler {
+	return Handler{
+		Name: SetMetadataHandlerName,
+		Fn: func(ctx context.Context, m *Machine) error {
+			return m.SetMetadata(ctx, m.Metadata)
+		},
+	}
+}
+
+var defaultValidationHandlerList = HandlerList{}.Append(
+	Handler{
+		Name: ValidateCfgHandlerName,
+		Fn: func(ctx context.Context, m *Machine) error {
+			// ensure that the configuration is valid for the
+			// FcInit handlers.
+			return m.cfg.Validate()
+		},
+	},
 )
 
-// HandlerList represents a list of named handler that
-// can be used to execute a flow of instructions for a given
-// machine.
+var defaultFcInitHandlerList = HandlerList{}.Append(
+	StartVMMHandler,
+	BootstrapLoggingHandler,
+	CreateMachineHandler,
+	CreateBootSourceHandler,
+	AttachDrivesHandler,
+	CreateNetworkInterfacesHandler,
+	AddVsocksHandler,
+)
+
+var defaultHandlers = Handlers{
+	Validation: defaultValidationHandlerList,
+	FcInit:     defaultFcInitHandlerList,
+}
+
+// Handler represents a named handler that contains a name and a function which
+// is used to execute during the initialization process of a machine.
+type Handler struct {
+	Name string
+	Fn   func(context.Context, *Machine) error
+}
+
+// Handlers is a container that houses categories of handler lists.
+type Handlers struct {
+	Validation HandlerList
+	FcInit     HandlerList
+}
+
+// Run will execute all handlers in the Handlers object by flattening the lists
+// into a single list and running.
+func (h Handlers) Run(ctx context.Context, m *Machine) error {
+	l := HandlerList{}.Append(
+		h.Validation.list...,
+	).Append(
+		h.FcInit.list...,
+	)
+
+	return l.Run(ctx, m)
+}
+
+// HandlerList represents a list of named handler that can be used to execute a
+// flow of instructions for a given machine.
 type HandlerList struct {
-	list []NamedHandler
+	list []Handler
 }
 
 // Append will append a new handler to the handler list.
-func (l HandlerList) Append(handlers ...NamedHandler) HandlerList {
+func (l HandlerList) Append(handlers ...Handler) HandlerList {
 	l.list = append(l.list, handlers...)
 
 	return l
 }
 
-// Remove will return an updated handler with all instances
-// of the specific named handler being removed.
+// Len return the length of the given handler list
+func (l HandlerList) Len() int {
+	return len(l.list)
+}
+
+// Has will iterate through the handler list and check to see if the the named
+// handler exists.
+func (l HandlerList) Has(name string) bool {
+	for _, h := range l.list {
+		if h.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Swap will replace all elements of the given name with the new handler.
+func (l HandlerList) Swap(handler Handler) HandlerList {
+	newList := HandlerList{}
+	for _, h := range l.list {
+		if h.Name == handler.Name {
+			newList.list = append(newList.list, handler)
+			continue
+		}
+
+		newList.list = append(newList.list, h)
+	}
+
+	return newList
+}
+
+// Swappend will either append, if there isn't an element within the handler
+// list, otherwise it will replace all elements with the given name.
+func (l HandlerList) Swappend(handler Handler) HandlerList {
+	if l.Has(handler.Name) {
+		return l.Swap(handler)
+	}
+
+	return l.Append(handler)
+}
+
+// Remove will return an updated handler with all instances of the specific
+// named handler being removed.
 func (l HandlerList) Remove(name string) HandlerList {
 	newList := HandlerList{}
 	for _, h := range l.list {
@@ -125,25 +217,17 @@ func (l HandlerList) Remove(name string) HandlerList {
 	return newList
 }
 
-// Clear clears the whole list of handlers
+// Clear clears all named handler in the list.
 func (l HandlerList) Clear() HandlerList {
 	l.list = l.list[0:0]
 	return l
 }
 
-// NamedHandler represents a named handler that contains a
-// name and a function which is used to execute during
-// the initialization process of a machine.
-type NamedHandler struct {
-	Name string
-	Fn   func(context.Context, *Machine) error
-}
-
-// Run will execute each instruction in the handler list. If an
-// error occurs in any of the handlers, then the list will halt
-// execution and return the error.
+// Run will execute each instruction in the handler list. If an error occurs in
+// any of the handlers, then the list will halt execution and return the error.
 func (l HandlerList) Run(ctx context.Context, m *Machine) error {
 	for _, handler := range l.list {
+		m.logger.Debugf("Running handler %s", handler.Name)
 		if err := handler.Fn(ctx, m); err != nil {
 			return err
 		}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,0 +1,422 @@
+package firecracker
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestHandlerListAppend(t *testing.T) {
+	h := HandlerList{}
+	h.Append(Handler{Name: "foo"})
+
+	if size := h.Len(); size != 0 {
+		t.Errorf("expected length to be '0', but received '%d'", size)
+	}
+
+	expectedNames := []string{
+		"foo",
+		"bar",
+		"baz",
+	}
+
+	for _, name := range expectedNames {
+		h = h.Append(Handler{Name: name})
+	}
+
+	for i, name := range expectedNames {
+		if e, a := name, h.list[i].Name; e != a {
+			t.Errorf("expected %q, but received %q", e, a)
+		}
+	}
+}
+
+func TestHandlerListRemove(t *testing.T) {
+	h := HandlerList{}.Append(
+		Handler{
+			Name: "foo",
+		},
+		Handler{
+			Name: "bar",
+		},
+		Handler{
+			Name: "baz",
+		},
+		Handler{
+			Name: "foo",
+		},
+		Handler{
+			Name: "baz",
+		},
+	)
+
+	h.Remove("foo")
+
+	if e, a := 5, h.Len(); e != a {
+		t.Errorf("expected '%d', but received '%d'", e, a)
+	}
+
+	h = h.Remove("foo")
+	if e, a := 3, h.Len(); e != a {
+		t.Errorf("expected '%d', but received '%d'", e, a)
+	}
+
+	if e, a := "bar", h.list[0].Name; e != a {
+		t.Errorf("expected %s, but received %s", e, a)
+	}
+
+	h = h.Remove("invalid-name")
+	if e, a := 3, h.Len(); e != a {
+		t.Errorf("expected '%d', but received '%d'", e, a)
+	}
+
+	h = h.Remove("baz")
+	if e, a := 1, h.Len(); e != a {
+		t.Errorf("expected '%d', but received '%d'", e, a)
+	}
+
+	h = h.Remove("bar")
+	if e, a := 0, h.Len(); e != a {
+		t.Errorf("expected '%d', but received '%d'", e, a)
+	}
+}
+
+func TestHandlerListClear(t *testing.T) {
+	h := HandlerList{}
+	h = h.Append(
+		Handler{Name: "foo"},
+		Handler{Name: "foo"},
+		Handler{Name: "foo"},
+		Handler{Name: "foo"},
+		Handler{Name: "foo"},
+		Handler{Name: "foo"},
+		Handler{Name: "foo"},
+	)
+
+	h.Clear()
+	if e, a := 7, h.Len(); e != a {
+		t.Errorf("expected '%d', but received '%d'", e, a)
+	}
+
+	h = h.Clear()
+	if e, a := 0, h.Len(); e != a {
+		t.Errorf("expected '%d', but received '%d'", e, a)
+	}
+}
+
+func TestHandlerListRun(t *testing.T) {
+	count := 0
+	bazErr := fmt.Errorf("baz error")
+
+	h := HandlerList{}
+	h = h.Append(
+		Handler{
+			Name: "foo",
+			Fn: func(ctx context.Context, m *Machine) error {
+				count++
+				return nil
+			},
+		},
+		Handler{
+			Name: "bar",
+			Fn: func(ctx context.Context, m *Machine) error {
+				count += 10
+				return nil
+			},
+		},
+		Handler{
+			Name: "baz",
+			Fn: func(ctx context.Context, m *Machine) error {
+				return bazErr
+			},
+		},
+		Handler{
+			Name: "qux",
+			Fn: func(ctx context.Context, m *Machine) error {
+				count *= 100
+				return nil
+			},
+		},
+	)
+
+	ctx := context.Background()
+	m := &Machine{
+		logger: log.NewEntry(log.New()),
+	}
+	if err := h.Run(ctx, m); err != bazErr {
+		t.Errorf("expected an error, but received %v", err)
+	}
+
+	if e, a := 11, count; e != a {
+		t.Errorf("expected '%d', but received '%d'", e, a)
+	}
+
+	h = h.Remove("baz")
+	if err := h.Run(ctx, m); err != nil {
+		t.Errorf("expected no error, but received %v", err)
+	}
+
+	if e, a := 2200, count; e != a {
+		t.Errorf("expected '%d', but received '%d'", e, a)
+	}
+}
+
+func TestHandlerListHas(t *testing.T) {
+	cases := []struct {
+		name     string
+		elemName string
+		list     HandlerList
+		expected bool
+	}{
+		{
+			name:     "contains",
+			elemName: "foo",
+			list: HandlerList{}.Append(
+				Handler{
+					Name: "foo",
+				},
+			),
+			expected: true,
+		},
+		{
+			name:     "does not contain",
+			elemName: "foo",
+			list:     HandlerList{},
+		},
+		{
+			name:     "similar names",
+			elemName: "foo",
+			list: HandlerList{}.Append(
+				Handler{
+					Name: "foo1",
+				},
+			),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if e, a := c.expected, c.list.Has(c.elemName); e != a {
+				t.Errorf("expected %t, but received %t", e, a)
+			}
+		})
+	}
+}
+
+func TestHandlerListSwappend(t *testing.T) {
+	fn := func(ctx context.Context, m *Machine) error {
+		return nil
+	}
+
+	cases := []struct {
+		name         string
+		list         HandlerList
+		elem         Handler
+		expectedList HandlerList
+	}{
+		{
+			name: "append one",
+			list: HandlerList{}.Append(
+				Handler{
+					Name: "bar",
+				},
+			),
+			elem: Handler{
+				Name: "foo",
+			},
+			expectedList: HandlerList{}.Append(
+				Handler{
+					Name: "bar",
+				},
+				Handler{
+					Name: "foo",
+				},
+			),
+		},
+		{
+			name: "swap single",
+			list: HandlerList{}.Append(
+				Handler{
+					Name: "bar",
+				},
+				Handler{
+					Name: "foo",
+				},
+			),
+			elem: Handler{
+				Name: "foo",
+				Fn:   fn,
+			},
+			expectedList: HandlerList{}.Append(
+				Handler{
+					Name: "bar",
+				},
+				Handler{
+					Name: "foo",
+					Fn:   fn,
+				},
+			),
+		},
+		{
+			name: "swap multiple",
+			list: HandlerList{}.Append(
+				Handler{
+					Name: "foo",
+				},
+				Handler{
+					Name: "bar",
+				},
+				Handler{
+					Name: "foo",
+				},
+			),
+			elem: Handler{
+				Name: "foo",
+				Fn:   fn,
+			},
+			expectedList: HandlerList{}.Append(
+				Handler{
+					Name: "foo",
+					Fn:   fn,
+				},
+				Handler{
+					Name: "bar",
+				},
+				Handler{
+					Name: "foo",
+					Fn:   fn,
+				},
+			),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			c.list = c.list.Swappend(c.elem)
+
+			if e, a := c.expectedList, c.list; !compareHandlerLists(e, a) {
+				t.Errorf("expected %v, but received %v", e, a)
+			}
+		})
+	}
+}
+
+func TestHandlerListReplace(t *testing.T) {
+	fn := func(ctx context.Context, m *Machine) error {
+		return nil
+	}
+
+	cases := []struct {
+		name         string
+		list         HandlerList
+		elem         Handler
+		expectedList HandlerList
+	}{
+		{
+			name: "swap none",
+			list: HandlerList{}.Append(
+				Handler{
+					Name: "bar",
+				},
+			),
+			elem: Handler{
+				Name: "foo",
+			},
+			expectedList: HandlerList{}.Append(
+				Handler{
+					Name: "bar",
+				},
+			),
+		},
+		{
+			name: "swap single",
+			list: HandlerList{}.Append(
+				Handler{
+					Name: "bar",
+				},
+				Handler{
+					Name: "foo",
+				},
+			),
+			elem: Handler{
+				Name: "foo",
+				Fn:   fn,
+			},
+			expectedList: HandlerList{}.Append(
+				Handler{
+					Name: "bar",
+				},
+				Handler{
+					Name: "foo",
+					Fn:   fn,
+				},
+			),
+		},
+		{
+			name: "swap multiple",
+			list: HandlerList{}.Append(
+				Handler{
+					Name: "foo",
+				},
+				Handler{
+					Name: "bar",
+				},
+				Handler{
+					Name: "foo",
+				},
+			),
+			elem: Handler{
+				Name: "foo",
+				Fn:   fn,
+			},
+			expectedList: HandlerList{}.Append(
+				Handler{
+					Name: "foo",
+					Fn:   fn,
+				},
+				Handler{
+					Name: "bar",
+				},
+				Handler{
+					Name: "foo",
+					Fn:   fn,
+				},
+			),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			c.list = c.list.Swap(c.elem)
+
+			if e, a := c.expectedList, c.list; !compareHandlerLists(e, a) {
+				t.Errorf("expected %v, but received %v", e, a)
+			}
+		})
+	}
+}
+
+func compareHandlerLists(l1, l2 HandlerList) bool {
+	if l1.Len() != l2.Len() {
+		return false
+	}
+
+	for i := 0; i < len(l1.list); i++ {
+		e1, e2 := l1.list[i], l2.list[i]
+
+		if e1.Name != e2.Name {
+			return false
+		}
+
+		v1 := reflect.ValueOf(e1.Fn)
+		v2 := reflect.ValueOf(e2.Fn)
+		if v1.Pointer() != v2.Pointer() {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pointer_helpers.go
+++ b/pointer_helpers.go
@@ -1,0 +1,31 @@
+package firecracker
+
+// BoolValue will return a boolean value. If the pointer is nil, then false
+// will be returned.
+func BoolValue(b *bool) bool {
+	if b == nil {
+		return false
+	}
+
+	return *b
+}
+
+// Bool will return a pointer value of the given parameter.
+func Bool(b bool) *bool {
+	return &b
+}
+
+// StringValue will return a string value. If the pointer is nil, then an empty
+// string will be returned.
+func StringValue(str *string) string {
+	if str == nil {
+		return ""
+	}
+
+	return *str
+}
+
+// String will return a pointer value of the given parameter.
+func String(str string) *string {
+	return &str
+}


### PR DESCRIPTION
*Description of changes:*
`LogFifo` and `MetricsFifo` can now log its contents to a file by setting the `FifoLogWriter` which is an `io.Writer` to handle the fifo streams content.

Some refactors here on how the `Machine` object flows through its instructions. Previously these instructions were all called during the initialization phase. However, to make the `Machine` more flexible and extendable, this introduces handler lists which is a command pattern queue. `Init` is no longer needed, as that is now handled through `Handlers`.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
