### PR TITLE
test: fix error in testStartInstance

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -280,9 +280,9 @@ func testStartInstance(ctx context.Context, t *testing.T, m *Machine) {
 			t.Errorf(`startInstance: %s
 Do you have permission to interact with /dev/vhost-vsock?
 Grant yourself permission with `+"`sudo setfacl -m u:${USER}:rw /dev/vhost-vsock`", syncErr.Payload.FaultMessage)
+		} else {
+			t.Errorf("startInstance failed: %s", err)
 		}
-	} else {
-		t.Errorf("startInstance failed: %s", err)
 	}
 }
 


### PR DESCRIPTION
A brace was misplaced during a fix from a merge conflict, causing
unintentional test failures.

Signed-off-by: Samuel Karp <skarp@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
