### PR TITLE
ensure tests have stopped VM upon completion

### DIFF
--- a/cmd/firectl/main_test.go
+++ b/cmd/firectl/main_test.go
@@ -147,6 +147,8 @@ func TestLogFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer m.StopVMM()
+
 	_, err = m.Init(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/machine_test.go
+++ b/machine_test.go
@@ -156,6 +156,7 @@ func TestStartVMM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer m.StopVMM()
 
 	timeout, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
 	defer cancel()


### PR DESCRIPTION
TestStartVMM was leaking a process due to not having proper cleanup when
tests have completed.

Fixes #33 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
