### PR TITLE
machine: StopVMM should not panic on nil Process 

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -11,10 +11,10 @@ will run tests in verbose mode.
 You need some external resources in order to run the tests, as described below:
 
 1. A firecracker binary (tested with 0.10.1), but any recent version should
-   work.  Must either be installed as `./firecracker` or the path must be
-   specified through the `FC_TEST_BIN` environment variable.
-2. Access to hardware virtualization via `/dev/kvm` and `/dev/vhost-vsock` (ensure you have mode
-   `+rw`!)
+   work.  Must either be installed as `./testdata/firecracker` or the path must
+   be specified through the `FC_TEST_BIN` environment variable.
+2. Access to hardware virtualization via `/dev/kvm` and `/dev/vhost-vsock`
+   (ensure you have mode `+rw`!)
 3. An uncompressed Linux kernel binary that can boot in Firecracker VM (Must be
    installed as `./testdata/vmlinux`)
 4. A tap device owned by your userid (Must be either named `fc-test-tap0` or

--- a/machine.go
+++ b/machine.go
@@ -378,7 +378,7 @@ func (m *Machine) StopVMM() error {
 }
 
 func (m *Machine) stopVMM() error {
-	if m.cmd != nil {
+	if m.cmd != nil && m.cmd.Process != nil {
 		log.Debug("stopVMM(): sending sigterm to firecracker")
 		return m.cmd.Process.Signal(syscall.SIGTERM)
 	}


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/firecracker-microvm/firecracker-go-sdk/issues/37

*Description of changes:*
* Check for nil Process before calling Signal
* Use a different channel for signaling the end of TestMicroVMExecution when startVMM fails
* Skip waiting for stabilization if the VMM isn't running
* Update HACKING.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
