### PR TITLE
adding support for jailer

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,6 +31,17 @@ steps:
       - 'ln -s /var/lib/fc-ci/vmlinux.bin testdata/vmlinux'
       - 'ln -s /usr/local/bin/firecracker testdata/firecracker'
       - 'ln -s /usr/local/bin/jailer testdata/jailer'
-      - "make test EXTRAGOARGS='-v -count=1'"
+      - 'sudo ip tuntap add fc-test-tap${BUILDKITE_BUILD_NUMBER} mode tap user $(sudo id -u buildkite-agent)'
+      - "DISABLE_ROOT_TESTS=true FC_TEST_TAP=fc-test-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1'"
+      - 'sudo ip tuntap del fc-test-tap${BUILDKITE_BUILD_NUMBER} mode tap'
+
+  - label: ':hammer: root tests'
+    commands:
+      - 'ln -s /var/lib/fc-ci/vmlinux.bin testdata/vmlinux'
+      - 'ln -s /usr/local/bin/firecracker testdata/firecracker'
+      - 'ln -s /usr/local/bin/jailer testdata/jailer'
+      - 'sudo ip tuntap add fc-root-tap${BUILDKITE_BUILD_NUMBER} mode tap user $(sudo id -u buildkite-agent)'
+      - "sudo FC_TEST_TAP=fc-root-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1'"
+      - 'sudo ip tuntap del fc-root-tap${BUILDKITE_BUILD_NUMBER} mode tap'
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"

--- a/HACKING.md
+++ b/HACKING.md
@@ -6,14 +6,17 @@ Testing
 
 Tests are written using Go's testing framework and can be run with the standard
 `go test` tool.  If you prefer to use the Makefile, `make test EXTRAGOARGS=-v`
-will run tests in verbose mode.
+will run tests in verbose mode. By default, the unit tests require root
+privileged access. This can be disabled by setting the `DISABLE_ROOT_TESTS`
+environment variable.
 
 You need some external resources in order to run the tests, as described below:
 
 1. A firecracker and jailer binary (tested with 0.12.0) must either be
    installed as `./testdata/firecracker` or the path must be specified through
    the `FC_TEST_BIN` environment variable. The jailer requires go test to be
-   run with sudo and can also be turned off with the `test.root-disable` flag.
+   run with sudo and can also be turned off by setting the `DISABLE_ROOT_TESTS`
+   env flag.
 2. Access to hardware virtualization via `/dev/kvm` and `/dev/vhost-vsock`
    (ensure you have mode `+rw`!)
 3. An uncompressed Linux kernel binary that can boot in Firecracker VM (Must be

--- a/HACKING.md
+++ b/HACKING.md
@@ -10,9 +10,10 @@ will run tests in verbose mode.
 
 You need some external resources in order to run the tests, as described below:
 
-1. A firecracker binary (tested with 0.10.1), but any recent version should
-   work.  Must either be installed as `./testdata/firecracker` or the path must
-   be specified through the `FC_TEST_BIN` environment variable.
+1. A firecracker and jailer binary (tested with 0.12.0) must either be
+   installed as `./testdata/firecracker` or the path must be specified through
+   the `FC_TEST_BIN` environment variable. The jailer requires go test to be
+   run with sudo and can also be turned off with the `test.root-disable` flag.
 2. Access to hardware virtualization via `/dev/kvm` and `/dev/vhost-vsock`
    (ensure you have mode `+rw`!)
 3. An uncompressed Linux kernel binary that can boot in Firecracker VM (Must be

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 A basic Go interface to the Firecracker API
 ====
 
-[![Build status](https://badge.buildkite.com/de08ca676829bedbf6de040c2c2ba1a5d2892e220997c2abdd.svg)](https://buildkite.com/firecracker-microvm/firecracker-go-sdk)
-
 This package is a Go library to interact with the Firecracker API. It
 is designed as an abstraction of the OpenAPI-generated client that
 allows for convenient manipulation of Firecracker VM from Go programs.

--- a/command_builder.go
+++ b/command_builder.go
@@ -57,7 +57,7 @@ func (b VMCommandBuilder) AddArgs(args ...string) VMCommandBuilder {
 	return b
 }
 
-// Bin return the bin that was set. If bin had not been set, then the default
+// Bin returns the bin that was set. If bin had not been set, then the default
 // will be returned.
 func (b VMCommandBuilder) Bin() string {
 	if len(b.bin) == 0 {

--- a/command_builder.go
+++ b/command_builder.go
@@ -20,8 +20,10 @@ import (
 	"os/exec"
 )
 
+const defaultFcBin = "firecracker"
+
 var defaultFirecrackerVMMCommandBuilder = VMCommandBuilder{}.
-	WithBin("firecracker").
+	WithBin(defaultFcBin).
 	WithStdin(os.Stdin).
 	WithStdout(os.Stdout).
 	WithStderr(os.Stderr)
@@ -55,8 +57,13 @@ func (b VMCommandBuilder) AddArgs(args ...string) VMCommandBuilder {
 	return b
 }
 
-// Bin return the bin that was set
+// Bin return the bin that was set. If bin had not been set, then the default
+// will be returned.
 func (b VMCommandBuilder) Bin() string {
+	if len(b.bin) == 0 {
+		return defaultFcBin
+	}
+
 	return b.bin
 }
 

--- a/command_builder_test.go
+++ b/command_builder_test.go
@@ -29,16 +29,11 @@ func TestVMCommandBuilder(t *testing.T) {
 func testVMCommandBuilderImmutable(t *testing.T) {
 	b := VMCommandBuilder{}
 	b.WithSocketPath("foo").
-		WithBin("bar").
 		WithArgs([]string{"baz", "qux"}).
 		AddArgs("moo", "cow")
 
 	if e, a := []string(nil), b.SocketPath(); !reflect.DeepEqual(e, a) {
 		t.Errorf("expected immutable builder, but socket path was set: %q", a)
-	}
-
-	if e, a := "", b.Bin(); e != a {
-		t.Errorf("bin had been set with %q, but should have been empty", a)
 	}
 
 	if e, a := ([]string)(nil), b.Args(); !reflect.DeepEqual(e, a) {

--- a/example_test.go
+++ b/example_test.go
@@ -220,7 +220,7 @@ func ExampleNetworkInterface_rateLimiting() {
 	}
 }
 
-func ExampleJailer_withBuilder() {
+func ExampleJailerCommandBuilder() {
 	ctx := context.Background()
 	// Creates a jailer command using the JailerCommandBuilder.
 	b := firecracker.NewJailerCommandBuilder().
@@ -264,6 +264,7 @@ func ExampleJailer_withBuilder() {
 		panic(err)
 	}
 
-	tCtx, _ := context.WithTimeout(ctx, time.Minute)
+	tCtx, cancelFn := context.WithTimeout(ctx, time.Minute)
+	defer cancelFn()
 	m.Wait(tCtx)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -99,11 +99,7 @@ func ExampleDrivesBuilder() {
 	}
 
 	ctx := context.Background()
-	m, err := firecracker.NewMachine(ctx, cfg)
-	if err != nil {
-		panic(fmt.Errorf("failed to create new machine: %v", err))
-	}
-
+	m := firecracker.NewMachine(ctx, cfg)
 	if err := m.Start(ctx); err != nil {
 		panic(fmt.Errorf("failed to initialize machine: %v", err))
 	}
@@ -141,11 +137,7 @@ func ExampleDrivesBuilder_driveOpt() {
 	}
 
 	ctx := context.Background()
-	m, err := firecracker.NewMachine(ctx, cfg)
-	if err != nil {
-		panic(fmt.Errorf("failed to create new machine: %v", err))
-	}
-
+	m := firecracker.NewMachine(ctx, cfg)
 	if err := m.Start(ctx); err != nil {
 		panic(fmt.Errorf("failed to initialize machine: %v", err))
 	}
@@ -249,6 +241,9 @@ func ExampleJailer_withBuilder() {
 
 	// Passes the custom jailer command into the constructor
 	m := firecracker.NewMachine(ctx, cfg, firecracker.WithProcessRunner(b.Build(ctx)))
+	// This does not copy any of the files over to the rootfs since a process
+	// runner was specified. This examples assumes that the files have been
+	// properly mounted.
 	if err := m.Start(ctx); err != nil {
 		panic(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -52,7 +52,11 @@ func ExampleWithProcessRunner_logging() {
 		WithStderr(stderr).
 		Build(ctx)
 
-	m := firecracker.NewMachine(ctx, cfg, firecracker.WithProcessRunner(cmd))
+	m, err := firecracker.NewMachine(ctx, cfg, firecracker.WithProcessRunner(cmd))
+	if err != nil {
+		panic(fmt.Errorf("failed to create new machine: %v", err))
+	}
+
 	defer os.Remove(cfg.SocketPath)
 
 	if err := m.Start(ctx); err != nil {
@@ -99,7 +103,11 @@ func ExampleDrivesBuilder() {
 	}
 
 	ctx := context.Background()
-	m := firecracker.NewMachine(ctx, cfg)
+	m, err := firecracker.NewMachine(ctx, cfg)
+	if err != nil {
+		panic(fmt.Errorf("failed to create new machine: %v", err))
+	}
+
 	if err := m.Start(ctx); err != nil {
 		panic(fmt.Errorf("failed to initialize machine: %v", err))
 	}
@@ -137,7 +145,11 @@ func ExampleDrivesBuilder_driveOpt() {
 	}
 
 	ctx := context.Background()
-	m := firecracker.NewMachine(ctx, cfg)
+	m, err := firecracker.NewMachine(ctx, cfg)
+	if err != nil {
+		panic(fmt.Errorf("failed to create new machine: %v", err))
+	}
+
 	if err := m.Start(ctx); err != nil {
 		panic(fmt.Errorf("failed to initialize machine: %v", err))
 	}
@@ -211,7 +223,7 @@ func ExampleNetworkInterface_rateLimiting() {
 func ExampleJailer_withBuilder() {
 	ctx := context.Background()
 	// Creates a jailer command using the JailerCommandBuilder.
-	b := firecracker.JailerCommandBuilder{}.
+	b := firecracker.NewJailerCommandBuilder().
 		WithID("my-test-id").
 		WithUID(123).
 		WithGID(100).
@@ -240,7 +252,11 @@ func ExampleJailer_withBuilder() {
 	}
 
 	// Passes the custom jailer command into the constructor
-	m := firecracker.NewMachine(ctx, cfg, firecracker.WithProcessRunner(b.Build(ctx)))
+	m, err := firecracker.NewMachine(ctx, cfg, firecracker.WithProcessRunner(b.Build(ctx)))
+	if err != nil {
+		panic(fmt.Errorf("failed to create new machine: %v", err))
+	}
+
 	// This does not copy any of the files over to the rootfs since a process
 	// runner was specified. This examples assumes that the files have been
 	// properly mounted.

--- a/example_test.go
+++ b/example_test.go
@@ -19,6 +19,13 @@ func ExampleWithProcessRunner_logging() {
 		MachineCfg: models.MachineConfiguration{
 			VcpuCount: 1,
 		},
+		JailerCfg: firecracker.JailerConfig{
+			GID:      firecracker.Int(100),
+			UID:      firecracker.Int(100),
+			ID:       "my-micro-vm",
+			NumaNode: firecracker.Int(0),
+			ExecFile: "/path/to/firecracker",
+		},
 	}
 
 	// stdout will be directed to this file

--- a/fctesting/utils.go
+++ b/fctesting/utils.go
@@ -1,0 +1,41 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fctesting
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+var rootDisabled bool
+
+func init() {
+	flag.BoolVar(&rootDisabled, "test.root-disable", false, "Disables tests that require root")
+}
+
+// RequiresRoot will ensure that tests that require root access are actually
+// root. In addition, this will skip root tests if the test.root-disable is set
+// to true
+func RequiresRoot(t testing.TB) {
+	if rootDisabled {
+		t.Skip("skipping test that requires root")
+	}
+
+	if e, a := 0, os.Getuid(); e != a {
+		t.Fatal("This test must be run as root. " +
+			"To disable tests that require root, " +
+			"run the tests with the -test.root-disable flag.")
+	}
+}

--- a/fctesting/utils.go
+++ b/fctesting/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -14,28 +14,32 @@
 package fctesting
 
 import (
-	"flag"
 	"os"
 	"testing"
 )
 
+const rootDisableEnvName = "DISABLE_ROOT_TESTS"
+
 var rootDisabled bool
 
 func init() {
-	flag.BoolVar(&rootDisabled, "test.root-disable", false, "Disables tests that require root")
+	if v := os.Getenv(rootDisableEnvName); len(v) != 0 {
+		rootDisabled = true
+	}
 }
 
 // RequiresRoot will ensure that tests that require root access are actually
-// root. In addition, this will skip root tests if the test.root-disable is set
-// to true
+// root. In addition, this will skip root tests if the DISABLE_ROOT_TESTS is
+// set to true
 func RequiresRoot(t testing.TB) {
 	if rootDisabled {
 		t.Skip("skipping test that requires root")
 	}
 
 	if e, a := 0, os.Getuid(); e != a {
-		t.Fatal("This test must be run as root. " +
-			"To disable tests that require root, " +
-			"run the tests with the -test.root-disable flag.")
+		t.Fatalf("This test must be run as root. "+
+			"To disable tests that require root, "+
+			"run the tests with the %s environment variable set.",
+			rootDisableEnvName)
 	}
 }

--- a/firecracker.go
+++ b/firecracker.go
@@ -228,27 +228,3 @@ func (f *Client) GetMachineConfig(opts ...GetMachineConfigOpt) (*ops.GetMachineC
 
 	return f.client.Operations.GetMachineConfig(p)
 }
-
-// PatchGuestDriveByIDOpt is a functional option to be used for the PutMmds API in setting
-// any additional optional fields.
-type PatchGuestDriveByIDOpt func(*ops.PatchGuestDriveByIDParams)
-
-// PatchGuestDriveByID is a wrapper for the swagger generated client to make calling of the
-// API easier.
-func (f *Client) PatchGuestDriveByID(ctx context.Context, driveID, pathOnHost string, opts ...PatchGuestDriveByIDOpt) (*ops.PatchGuestDriveByIDNoContent, error) {
-	params := ops.NewPatchGuestDriveByIDParams()
-	params.SetContext(ctx)
-
-	partialDrive := models.PartialDrive{
-		DriveID:    &driveID,
-		PathOnHost: &pathOnHost,
-	}
-	params.SetBody(&partialDrive)
-	params.DriveID = driveID
-
-	for _, opt := range opts {
-		opt(params)
-	}
-
-	return f.client.Operations.PatchGuestDriveByID(params)
-}

--- a/handlers.go
+++ b/handlers.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -34,8 +34,8 @@ const (
 	ValidateJailerCfgHandlerName = "validate.JailerCfg"
 )
 
-// HandlersAdaptor is an interface used to modify a given set of handlers.
-type HandlersAdaptor interface {
+// HandlersAdapter is an interface used to modify a given set of handlers.
+type HandlersAdapter interface {
 	AdaptHandlers(*Handlers) error
 }
 
@@ -70,8 +70,8 @@ var JailerConfigValidationHandler = Handler{
 			return fmt.Errorf("A root drive must be present in the drive list")
 		}
 
-		if m.cfg.JailerCfg.DevMapperStrategy == nil {
-			return fmt.Errorf("DevMapperStrategy cannot be nil")
+		if m.cfg.JailerCfg.ChrootStrategy == nil {
+			return fmt.Errorf("ChrootStrategy cannot be nil")
 		}
 
 		if len(m.cfg.JailerCfg.ExecFile) == 0 {

--- a/handlers.go
+++ b/handlers.go
@@ -34,6 +34,11 @@ const (
 	ValidateJailerCfgHandlerName = "validate.JailerCfg"
 )
 
+// HandlersAdaptor is an interface used to modify a given set of handlers.
+type HandlersAdaptor interface {
+	AdaptHandlers(*Handlers) error
+}
+
 // ConfigValidationHandler is used to validate that required fields are
 // present. This validator is to be used when the jailer is turned off.
 var ConfigValidationHandler = Handler{
@@ -49,7 +54,7 @@ var ConfigValidationHandler = Handler{
 var JailerConfigValidationHandler = Handler{
 	Name: ValidateJailerCfgHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		if m.cfg.DisableJailer {
+		if !m.cfg.EnableJailer {
 			return nil
 		}
 
@@ -63,6 +68,10 @@ var JailerConfigValidationHandler = Handler{
 
 		if !hasRoot {
 			return fmt.Errorf("A root drive must be present in the drive list")
+		}
+
+		if m.cfg.JailerCfg.DevMapperStrategy == nil {
+			return fmt.Errorf("DevMapperStrategy cannot be nil")
 		}
 
 		if len(m.cfg.JailerCfg.ExecFile) == 0 {

--- a/handlers.go
+++ b/handlers.go
@@ -127,8 +127,12 @@ var defaultValidationHandlerList = HandlerList{}.Append(
 				return nil
 			}
 
-			if m.cfg.JailerCfg.ExecFile == nil {
+			if len(m.cfg.JailerCfg.ExecFile) == 0 {
 				return fmt.Errorf("exec file must be specified when using jailer mode")
+			}
+
+			if len(m.cfg.JailerCfg.ID) == 0 {
+				return fmt.Errorf("id must be specified when using jailer mode")
 			}
 
 			if m.cfg.JailerCfg.GID == nil {
@@ -137,10 +141,6 @@ var defaultValidationHandlerList = HandlerList{}.Append(
 
 			if m.cfg.JailerCfg.UID == nil {
 				return fmt.Errorf("UID must be specified when using jailer mode")
-			}
-
-			if m.cfg.JailerCfg.ID == nil {
-				return fmt.Errorf("ID must be specified when using jailer mode")
 			}
 
 			if m.cfg.JailerCfg.NumaNode == nil {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -399,6 +399,87 @@ func TestHandlerListReplace(t *testing.T) {
 	}
 }
 
+func TestHandlerListAppendAfter(t *testing.T) {
+	cases := []struct {
+		name         string
+		list         HandlerList
+		afterName    string
+		elem         Handler
+		expectedList HandlerList
+	}{
+		{
+			name: "no append",
+			list: HandlerList{}.Append(
+				Handler{
+					Name: "foo",
+				},
+				Handler{
+					Name: "bar",
+				},
+				Handler{
+					Name: "baz",
+				},
+			),
+			afterName: "not exist",
+			elem: Handler{
+				Name: "qux",
+			},
+			expectedList: HandlerList{}.Append(
+				Handler{
+					Name: "foo",
+				},
+				Handler{
+					Name: "bar",
+				},
+				Handler{
+					Name: "baz",
+				},
+			),
+		},
+		{
+			name: "append after",
+			list: HandlerList{}.Append(
+				Handler{
+					Name: "foo",
+				},
+				Handler{
+					Name: "bar",
+				},
+				Handler{
+					Name: "baz",
+				},
+			),
+			afterName: "foo",
+			elem: Handler{
+				Name: "qux",
+			},
+			expectedList: HandlerList{}.Append(
+				Handler{
+					Name: "foo",
+				},
+				Handler{
+					Name: "qux",
+				},
+				Handler{
+					Name: "bar",
+				},
+				Handler{
+					Name: "baz",
+				},
+			),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			c.list = c.list.AppendAfter(c.afterName, c.elem)
+			if e, a := c.expectedList, c.list; !compareHandlerLists(e, a) {
+				t.Errorf("expected %v, but received %v", e, a)
+			}
+		})
+	}
+}
+
 func compareHandlerLists(l1, l2 HandlerList) bool {
 	if l1.Len() != l2.Len() {
 		return false

--- a/jailer.go
+++ b/jailer.go
@@ -1,0 +1,376 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package firecracker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
+)
+
+// SecCompLevelValue represents a secure computing level type.
+type SecCompLevelValue int
+
+// secure computing levels
+const (
+	// SecCompLevelDisable is the default value.
+	SecCompLevelDisable = SecCompLevelValue(0)
+	// SecCompLevelBasic prohibits syscalls not whitelisted by Firecracker.
+	SecCompLevelBasic = SecCompLevelValue(1)
+	// SecCompLevelAdvanced adds further checks on some of the parameters of the
+	// allowed syscalls.
+	SecCompLevelAdvanced = SecCompLevelValue(2)
+)
+
+// JailerConfig is jailer specific configuration needed to execute the jailer.
+type JailerConfig struct {
+	GID           *int
+	UID           *int
+	ID            *string
+	NumaNode      *int
+	ExecFile      *string
+	ChrootBaseDir string
+	NetNS         string
+	Daemonize     bool
+	SecCompLevel  SecCompLevelValue
+}
+
+// JailerCommandBuilder will build a jailer command. This can be used to
+// specify that a jailed firecracker executable wants to be run on the Machine.
+type JailerCommandBuilder struct {
+	id       string
+	uid      int
+	gid      int
+	execFile string
+	node     int
+
+	// optional params
+	chrootBaseDir string
+	netNS         string
+	daemonize     bool
+	secCompLevel  SecCompLevelValue
+
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+}
+
+// Args returns the specified set of args to be used
+// in command construction.
+func (b JailerCommandBuilder) Args() []string {
+	args := []string{}
+	args = append(args, b.ID()...)
+	args = append(args, b.UID()...)
+	args = append(args, b.GID()...)
+	args = append(args, b.ExecFile()...)
+	args = append(args, b.NumaNode()...)
+
+	if len(b.chrootBaseDir) > 0 {
+		args = append(args, b.ChrootBaseDir()...)
+	}
+
+	if len(b.netNS) > 0 {
+		args = append(args, b.NetNS()...)
+	}
+
+	args = append(args, b.SecCompLevel()...)
+
+	if b.daemonize {
+		args = append(args, "--daemonize")
+	}
+
+	return args
+}
+
+// ID will return the command arguments regarding the id.
+func (b JailerCommandBuilder) ID() []string {
+	return []string{
+		"--id",
+		b.id,
+	}
+}
+
+// WithID will set the specified id to the builder.
+func (b JailerCommandBuilder) WithID(id string) JailerCommandBuilder {
+	b.id = id
+	return b
+}
+
+// UID will return the command arguments regarding the uid.
+func (b JailerCommandBuilder) UID() []string {
+	return []string{
+		"--uid",
+		strconv.Itoa(b.uid),
+	}
+}
+
+// WithUID will set the specified uid to the builder.
+func (b JailerCommandBuilder) WithUID(uid int) JailerCommandBuilder {
+	b.uid = uid
+	return b
+}
+
+// GID will return the command arguments regarding the gid.
+func (b JailerCommandBuilder) GID() []string {
+	return []string{
+		"--gid",
+		strconv.Itoa(b.gid),
+	}
+}
+
+// WithGID will set the specified gid to the builder.
+func (b JailerCommandBuilder) WithGID(gid int) JailerCommandBuilder {
+	b.gid = gid
+	return b
+}
+
+// ExecFile will return the command arguments regarding the exec file.
+func (b JailerCommandBuilder) ExecFile() []string {
+	return []string{
+		"--exec-file",
+		b.execFile,
+	}
+}
+
+// WithExecFile will set the specified path to the builder. This represents a
+// firecracker binary used when calling the jailer.
+func (b JailerCommandBuilder) WithExecFile(path string) JailerCommandBuilder {
+	b.execFile = path
+	return b
+}
+
+// NumaNode will return the command arguments regarding the numa node.
+func (b JailerCommandBuilder) NumaNode() []string {
+	return []string{
+		"--node",
+		strconv.Itoa(b.node),
+	}
+}
+
+// WithNumaNode uses the specfied node for the jailer. This represents the numa
+// node that the process will get assigned to.
+func (b JailerCommandBuilder) WithNumaNode(node int) JailerCommandBuilder {
+	b.node = node
+	return b
+}
+
+// ChrootBaseDir will return the command arguments regarding the chroot base
+// directory.
+func (b JailerCommandBuilder) ChrootBaseDir() []string {
+	return []string{
+		"--chroot-base-dir",
+		b.chrootBaseDir,
+	}
+}
+
+// WithChrootBaseDir will set the given path as the chroot base directory. This
+// specifies where chroot jails are built and defaults to /srv/jailer.
+func (b JailerCommandBuilder) WithChrootBaseDir(path string) JailerCommandBuilder {
+	b.chrootBaseDir = path
+	return b
+}
+
+// NetNS will return the command arguments regarding the net namespace.
+func (b JailerCommandBuilder) NetNS() []string {
+	return []string{
+		"--netns",
+		b.netNS,
+	}
+}
+
+// WithNetNS will set the given path to the net namespace of the builder. This
+// represents the path to a network namespace handle and will be used to join
+// the associated network namepsace.
+func (b JailerCommandBuilder) WithNetNS(path string) JailerCommandBuilder {
+	b.netNS = path
+	return b
+}
+
+// WithDaemonize will specify whether to set stdio to /dev/null
+func (b JailerCommandBuilder) WithDaemonize(daemonize bool) JailerCommandBuilder {
+	b.daemonize = daemonize
+	return b
+}
+
+// SecCompLevel will return the command arguments regarding secure computing
+// level.
+func (b JailerCommandBuilder) SecCompLevel() []string {
+	return []string{
+		"--seccomp-level",
+		strconv.Itoa(int(b.secCompLevel)),
+	}
+}
+
+// WithSecCompLevel will set the provided level to the builder. This represents
+// the seccomp filters that should be installed and how restrictive they should
+// be.
+func (b JailerCommandBuilder) WithSecCompLevel(level SecCompLevelValue) JailerCommandBuilder {
+	b.secCompLevel = level
+	return b
+}
+
+// Stdout will return the stdout that will be used when creating the
+// firecracker exec.Command
+func (b JailerCommandBuilder) Stdout() io.Writer {
+	return b.stdout
+}
+
+// WithStdout specifies which io.Writer to use in place of the os.Stdout in the
+// firecracker exec.Command.
+func (b JailerCommandBuilder) WithStdout(stdout io.Writer) JailerCommandBuilder {
+	b.stdout = stdout
+	return b
+}
+
+// Stderr will return the stderr that will be used when creating the
+// firecracker exec.Command
+func (b JailerCommandBuilder) Stderr() io.Writer {
+	return b.stderr
+}
+
+// WithStderr specifies which io.Writer to use in place of the os.Stderr in the
+// firecracker exec.Command.
+func (b JailerCommandBuilder) WithStderr(stderr io.Writer) JailerCommandBuilder {
+	b.stderr = stderr
+	return b
+}
+
+// Stdin will return the stdin that will be used when creating the firecracker
+// exec.Command
+func (b JailerCommandBuilder) Stdin() io.Reader {
+	return b.stdin
+}
+
+// WithStdin specifies which io.Reader to use in place of the os.Stdin in the
+// firecracker exec.Command.
+func (b JailerCommandBuilder) WithStdin(stdin io.Reader) JailerCommandBuilder {
+	b.stdin = stdin
+	return b
+}
+
+// Build will build a jailer command.
+func (b JailerCommandBuilder) Build(ctx context.Context) *exec.Cmd {
+	cmd := exec.CommandContext(
+		ctx,
+		"jailer",
+		b.Args()...,
+	)
+
+	fmt.Println("COMMAND", cmd.Args)
+
+	if stdin := b.Stdin(); stdin != nil {
+		cmd.Stdin = stdin
+	}
+
+	if stdout := b.Stdout(); stdout != nil {
+		cmd.Stdout = stdout
+	}
+
+	if stderr := b.Stderr(); stderr != nil {
+		cmd.Stderr = stderr
+	}
+
+	return cmd
+}
+
+// Jail will set up proper handlers and remove configuuration validation due to
+// stating of files
+func jail(ctx context.Context, m *Machine, cfg Config) {
+	m.Handlers.Validation = m.Handlers.Validation.Remove(ValidateCfgHandlerName)
+
+	id := StringValue(cfg.JailerCfg.ID)
+	b := JailerCommandBuilder{}.
+		WithID(id).
+		WithUID(IntValue(cfg.JailerCfg.UID)).
+		WithGID(IntValue(cfg.JailerCfg.GID)).
+		WithNumaNode(IntValue(cfg.JailerCfg.NumaNode)).
+		WithExecFile(StringValue(cfg.JailerCfg.ExecFile)).
+		WithDaemonize(cfg.JailerCfg.Daemonize).
+		WithSecCompLevel(cfg.JailerCfg.SecCompLevel).
+		WithStdout(os.Stdout).
+		WithStderr(os.Stderr)
+
+	rootfs := ""
+	if len(cfg.JailerCfg.ChrootBaseDir) > 0 {
+		rootfs = filepath.Join(cfg.JailerCfg.ChrootBaseDir, "firecracker", id)
+		b = b.WithChrootBaseDir(cfg.JailerCfg.ChrootBaseDir)
+	} else {
+		const defaultJailerPath = "/srv/jailer/firecracker"
+		rootfs = filepath.Join(defaultJailerPath, id)
+	}
+
+	if len(cfg.JailerCfg.NetNS) > 0 {
+		b = b.WithNetNS(cfg.JailerCfg.NetNS)
+	}
+
+	m.cmd = b.Build(ctx)
+	// TODO: hmm, do we actually want to overwrite the socket path?
+	m.cfg.SocketPath = filepath.Join(rootfs, "api.socket")
+
+	m.Handlers.Validation = m.Handlers.Validation.Remove(ValidateCfgHandlerName)
+	m.Handlers.FcInit = m.Handlers.FcInit.AppendAfter(CreateMachineHandlerName, Handler{
+		Name: "fcinit.CopyFilesToRootFS",
+		Fn: func(ctx context.Context, m *Machine) error {
+
+			// copy kernel image to root fs
+			kernelImageFileName := filepath.Base(m.cfg.KernelImagePath)
+			if err := copyFileToRootFS(
+				m.cfg.JailerCfg,
+				filepath.Join(rootfs, "root", kernelImageFileName),
+				m.cfg.KernelImagePath,
+			); err != nil {
+				return err
+			}
+
+			var rootDrive models.Drive
+			rootDriveIndex := 0
+			for i, drive := range m.cfg.Drives {
+				if BoolValue(drive.IsRootDevice) {
+					rootDrive = drive
+					rootDriveIndex = i
+					break
+				}
+			}
+
+			rootHostPath := StringValue(rootDrive.PathOnHost)
+			// copy root drive to root fs
+			rootdriveFileName := filepath.Base(rootHostPath)
+			if err := copyFileToRootFS(
+				m.cfg.JailerCfg,
+				filepath.Join(rootfs, "root", rootdriveFileName),
+				rootHostPath,
+			); err != nil {
+				return err
+			}
+
+			m.cfg.Drives[rootDriveIndex].PathOnHost = &rootdriveFileName
+			m.cfg.KernelImagePath = kernelImageFileName
+			return nil
+		},
+	})
+}
+
+func copyFileToRootFS(cfg JailerConfig, dst, src string) error {
+	if err := os.Link(src, dst); err != nil {
+		return err
+	}
+
+	return os.Chown(dst, IntValue(cfg.UID), IntValue(cfg.GID))
+}

--- a/jailer_test.go
+++ b/jailer_test.go
@@ -76,7 +76,7 @@ func TestJailerBuilder(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			b := JailerCommandBuilder{}.
+			b := NewJailerCommandBuilder().
 				WithID(c.jailerCfg.ID).
 				WithUID(IntValue(c.jailerCfg.UID)).
 				WithGID(IntValue(c.jailerCfg.GID)).
@@ -116,11 +116,12 @@ func TestJail(t *testing.T) {
 	}
 	cfg := &Config{
 		JailerCfg: JailerConfig{
-			ID:       "test-id",
-			UID:      Int(123),
-			GID:      Int(456),
-			NumaNode: Int(0),
-			ExecFile: "/path/to/firecracker",
+			ID:                "test-id",
+			UID:               Int(123),
+			GID:               Int(456),
+			NumaNode:          Int(0),
+			ExecFile:          "/path/to/firecracker",
+			DevMapperStrategy: NewNaiveDevMapperStrategy("path", "kernel-image-path"),
 		},
 	}
 	jail(context.Background(), m, cfg)

--- a/jailer_test.go
+++ b/jailer_test.go
@@ -1,0 +1,163 @@
+package firecracker
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestJailerBuilder(t *testing.T) {
+	cases := []struct {
+		name         string
+		jailerCfg    JailerConfig
+		expectedArgs []string
+		jailerBin    string
+	}{
+		{
+			name: "required fields",
+			jailerCfg: JailerConfig{
+				ID:       "my-test-id",
+				UID:      Int(123),
+				GID:      Int(100),
+				NumaNode: Int(0),
+				ExecFile: "/path/to/firecracker",
+			},
+			expectedArgs: []string{
+				defaultJailerBin,
+				"--id",
+				"my-test-id",
+				"--uid",
+				"123",
+				"--gid",
+				"100",
+				"--exec-file",
+				"/path/to/firecracker",
+				"--node",
+				"0",
+				"--seccomp-level",
+				"0",
+			},
+		},
+		{
+			name:      "optional fields",
+			jailerBin: "foo",
+			jailerCfg: JailerConfig{
+				ID:            "my-test-id",
+				UID:           Int(123),
+				GID:           Int(100),
+				NumaNode:      Int(1),
+				ExecFile:      "/path/to/firecracker",
+				NetNS:         "/net/namespace",
+				ChrootBaseDir: "/tmp",
+				SeccompLevel:  SeccompLevelAdvanced,
+			},
+			expectedArgs: []string{
+				"foo",
+				"--id",
+				"my-test-id",
+				"--uid",
+				"123",
+				"--gid",
+				"100",
+				"--exec-file",
+				"/path/to/firecracker",
+				"--node",
+				"1",
+				"--chroot-base-dir",
+				"/tmp",
+				"--netns",
+				"/net/namespace",
+				"--seccomp-level",
+				"2",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			b := JailerCommandBuilder{}.
+				WithID(c.jailerCfg.ID).
+				WithUID(IntValue(c.jailerCfg.UID)).
+				WithGID(IntValue(c.jailerCfg.GID)).
+				WithNumaNode(IntValue(c.jailerCfg.NumaNode)).
+				WithSeccompLevel(c.jailerCfg.SeccompLevel).
+				WithExecFile(c.jailerCfg.ExecFile)
+
+			if len(c.jailerBin) > 0 {
+				b = b.WithBin(c.jailerBin)
+			}
+
+			if len(c.jailerCfg.ChrootBaseDir) > 0 {
+				b = b.WithChrootBaseDir(c.jailerCfg.ChrootBaseDir)
+			}
+
+			if len(c.jailerCfg.NetNS) > 0 {
+				b = b.WithNetNS(c.jailerCfg.NetNS)
+			}
+
+			if c.jailerCfg.Daemonize {
+				b = b.WithDaemonize(c.jailerCfg.Daemonize)
+			}
+
+			cmd := b.Build(context.Background())
+			if e, a := c.expectedArgs, cmd.Args; !reflect.DeepEqual(e, a) {
+				t.Errorf("expected args %v, but received %v", e, a)
+			}
+		})
+	}
+}
+
+func TestJail(t *testing.T) {
+	m := &Machine{
+		Handlers: Handlers{
+			FcInit: HandlerList{}.Append(CreateMachineHandler),
+		},
+	}
+	cfg := &Config{
+		JailerCfg: JailerConfig{
+			ID:       "test-id",
+			UID:      Int(123),
+			GID:      Int(456),
+			NumaNode: Int(0),
+			ExecFile: "/path/to/firecracker",
+		},
+	}
+	jail(context.Background(), m, cfg)
+
+	expectedArgs := []string{
+		defaultJailerBin,
+		"--id",
+		"test-id",
+		"--uid",
+		"123",
+		"--gid",
+		"456",
+		"--exec-file",
+		"/path/to/firecracker",
+		"--node",
+		"0",
+		"--seccomp-level",
+		"0",
+	}
+
+	if e, a := expectedArgs, m.cmd.Args; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected args %v, but received %v", e, a)
+	}
+
+	if e, a := filepath.Join(defaultJailerPath, cfg.JailerCfg.ID, "api.socket"), cfg.SocketPath; e != a {
+		t.Errorf("expected socket path %q, but received %q", e, a)
+	}
+
+	foundJailerHandler := false
+	for _, handler := range m.Handlers.FcInit.list {
+		if handler.Name == LinkFilesToRootFSHandlerName {
+			foundJailerHandler = true
+			break
+		}
+	}
+
+	if !foundJailerHandler {
+		t.Errorf("did not find link files handler")
+	}
+}

--- a/jailer_test.go
+++ b/jailer_test.go
@@ -116,12 +116,12 @@ func TestJail(t *testing.T) {
 	}
 	cfg := &Config{
 		JailerCfg: JailerConfig{
-			ID:                "test-id",
-			UID:               Int(123),
-			GID:               Int(456),
-			NumaNode:          Int(0),
-			ExecFile:          "/path/to/firecracker",
-			DevMapperStrategy: NewNaiveDevMapperStrategy("path", "kernel-image-path"),
+			ID:             "test-id",
+			UID:            Int(123),
+			GID:            Int(456),
+			NumaNode:       Int(0),
+			ExecFile:       "/path/to/firecracker",
+			ChrootStrategy: NewNaiveChrootStrategy("path", "kernel-image-path"),
 		},
 	}
 	jail(context.Background(), m, cfg)

--- a/machine.go
+++ b/machine.go
@@ -101,6 +101,10 @@ type Config struct {
 // Validate will ensure that the required fields are set and that
 // the fields are valid values.
 func (cfg *Config) Validate() error {
+	if cfg.DisableValidation {
+		return nil
+	}
+
 	if _, err := os.Stat(cfg.KernelImagePath); err != nil {
 		return fmt.Errorf("failed to stat kernal image path, %q: %v", cfg.KernelImagePath, err)
 	}
@@ -210,7 +214,7 @@ func NewMachine(ctx context.Context, cfg Config, opts ...Opt) *Machine {
 			WithSocketPath(m.cfg.SocketPath).
 			Build(ctx)
 	} else {
-		jail(ctx, m, cfg)
+		jail(ctx, m, &cfg)
 	}
 
 	for _, opt := range opts {

--- a/machine_test.go
+++ b/machine_test.go
@@ -100,9 +100,9 @@ func TestJailerMicroVMExecution(t *testing.T) {
 			GID:           Int(100),
 			UID:           Int(123),
 			NumaNode:      Int(0),
-			ID:            String("test-id"),
+			ID:            "test-id",
 			ChrootBaseDir: testDataPath,
-			ExecFile:      String(getFirecrackerBinaryPath()),
+			ExecFile:      getFirecrackerBinaryPath(),
 		},
 	}
 

--- a/pointer_helpers.go
+++ b/pointer_helpers.go
@@ -45,7 +45,8 @@ func Int64Value(v *int64) int64 {
 	return *v
 }
 
-// IntValue .
+// IntValue will return an int value. If the pointer is nil, zero will be
+// returned.
 func IntValue(v *int) int {
 	if v == nil {
 		return 0
@@ -54,7 +55,7 @@ func IntValue(v *int) int {
 	return *v
 }
 
-// Int .
+// Int will return a pointer value of the given parameters.
 func Int(v int) *int {
 	return &v
 }

--- a/pointer_helpers.go
+++ b/pointer_helpers.go
@@ -44,3 +44,17 @@ func Int64Value(v *int64) int64 {
 
 	return *v
 }
+
+// IntValue .
+func IntValue(v *int) int {
+	if v == nil {
+		return 0
+	}
+
+	return *v
+}
+
+// Int .
+func Int(v int) *int {
+	return &v
+}


### PR DESCRIPTION
Adds support for firecracker's jailer. This allows for more secure virtualization through creation of namespaces and cgroups. Jailer can be turned on by setting the `EnableJailer` flag. This also implements a very naive mapper and issue #56 is to implement a smarter mapper.

`go test` requires sudo since jailer requires sudo...

Fixes #11 