### PR TITLE
Adding drives builder

### DIFF
--- a/drives.go
+++ b/drives.go
@@ -1,0 +1,65 @@
+package firecracker
+
+import (
+	"strconv"
+
+	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
+)
+
+const rootDriveName = "root-drive"
+
+// DrivesBuilder is a builder that will build an array of drives used to set up
+// the firecracker microVM. The DriveID will be an incrementing number starting
+// at one
+type DrivesBuilder struct {
+	rootDrive models.Drive
+	drives    []models.Drive
+}
+
+// NewDrivesBuilder will return a new DrivesBuilder with a given rootfs.
+func NewDrivesBuilder(rootDrivePath string) DrivesBuilder {
+	return DrivesBuilder{}.WithRootDrive(rootDrivePath)
+}
+
+// DriveOpt represents an optional function used to allow for specific
+// customization of the models.Drive structure.
+type DriveOpt func(*models.Drive)
+
+// WithRootDrive will set the given builder with the a new root path. The root
+// drive will be set to read and write by default.
+func (b DrivesBuilder) WithRootDrive(rootDrivePath string, opts ...DriveOpt) DrivesBuilder {
+	b.rootDrive = models.Drive{
+		DriveID:      String(rootDriveName),
+		PathOnHost:   &rootDrivePath,
+		IsRootDevice: Bool(true),
+		IsReadOnly:   Bool(false),
+	}
+
+	for _, opt := range opts {
+		opt(&b.rootDrive)
+	}
+
+	return b
+}
+
+// AddDrive will add a new drive to the given builder.
+func (b DrivesBuilder) AddDrive(path string, readOnly bool, opts ...DriveOpt) DrivesBuilder {
+	drive := models.Drive{
+		DriveID:      String(strconv.Itoa(len(b.drives))),
+		PathOnHost:   &path,
+		IsRootDevice: Bool(false),
+		IsReadOnly:   &readOnly,
+	}
+
+	for _, opt := range opts {
+		opt(&drive)
+	}
+
+	b.drives = append(b.drives, drive)
+	return b
+}
+
+// Build will construct an array of drives with the root drive at the very end.
+func (b DrivesBuilder) Build() []models.Drive {
+	return append(b.drives, b.rootDrive)
+}

--- a/drives_test.go
+++ b/drives_test.go
@@ -1,0 +1,112 @@
+package firecracker
+
+import (
+	"reflect"
+	"testing"
+
+	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
+)
+
+func TestDrivesBuilder(t *testing.T) {
+	expectedPath := "/path/to/rootfs"
+	expectedDrives := []models.Drive{
+		{
+			DriveID:      String(rootDriveName),
+			PathOnHost:   &expectedPath,
+			IsRootDevice: Bool(true),
+			IsReadOnly:   Bool(false),
+		},
+	}
+
+	drives := NewDrivesBuilder(expectedPath).Build()
+	if e, a := expectedDrives, drives; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected drives %v, but received %v", e, a)
+	}
+}
+
+func TestDrivesBuilderWithRootDrive(t *testing.T) {
+	expectedPath := "/path/to/rootfs"
+	expectedDrives := []models.Drive{
+		{
+			DriveID:      String("foo"),
+			PathOnHost:   &expectedPath,
+			IsRootDevice: Bool(true),
+			IsReadOnly:   Bool(false),
+		},
+	}
+
+	b := NewDrivesBuilder(expectedPath)
+	drives := b.WithRootDrive(expectedPath, func(drive *models.Drive) {
+		drive.DriveID = String("foo")
+	}).Build()
+
+	if e, a := expectedDrives, drives; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected drives %v, but received %v", e, a)
+	}
+}
+
+func TestDrivesBuilderAddDrive(t *testing.T) {
+	rootPath := "/root/path"
+	drivesToAdd := []struct {
+		Path     string
+		ReadOnly bool
+		Opt      func(drive *models.Drive)
+	}{
+		{
+			Path:     "/2",
+			ReadOnly: true,
+		},
+		{
+			Path:     "/3",
+			ReadOnly: false,
+		},
+		{
+			Path:     "/4",
+			ReadOnly: false,
+			Opt: func(drive *models.Drive) {
+				drive.Partuuid = "uuid"
+			},
+		},
+	}
+	expectedDrives := []models.Drive{
+		{
+			DriveID:      String("0"),
+			PathOnHost:   String("/2"),
+			IsRootDevice: Bool(false),
+			IsReadOnly:   Bool(true),
+		},
+		{
+			DriveID:      String("1"),
+			PathOnHost:   String("/3"),
+			IsRootDevice: Bool(false),
+			IsReadOnly:   Bool(false),
+		},
+		{
+			DriveID:      String("2"),
+			PathOnHost:   String("/4"),
+			IsRootDevice: Bool(false),
+			IsReadOnly:   Bool(false),
+			Partuuid:     "uuid",
+		},
+		{
+			DriveID:      String(rootDriveName),
+			PathOnHost:   &rootPath,
+			IsRootDevice: Bool(true),
+			IsReadOnly:   Bool(false),
+		},
+	}
+
+	b := NewDrivesBuilder(rootPath)
+	for _, drive := range drivesToAdd {
+		if drive.Opt != nil {
+			b = b.AddDrive(drive.Path, drive.ReadOnly, drive.Opt)
+		} else {
+			b = b.AddDrive(drive.Path, drive.ReadOnly)
+		}
+	}
+
+	drives := b.Build()
+	if e, a := expectedDrives, drives; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected drives %v, but received %v", e, a)
+	}
+}

--- a/pointer_helpers.go
+++ b/pointer_helpers.go
@@ -29,3 +29,18 @@ func StringValue(str *string) string {
 func String(str string) *string {
 	return &str
 }
+
+// Int64 will return a pointer value of the given parameter.
+func Int64(v int64) *int64 {
+	return &v
+}
+
+// Int64Value will return an int64 value. If the pointer is nil, then zero will
+// be returned.
+func Int64Value(v *int64) int64 {
+	if v == nil {
+		return 0
+	}
+
+	return *v
+}


### PR DESCRIPTION
Adds a drives builder to help users with building a series of drives
without needing to know the intricate details of firecracker's API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
