### PR TITLE
seperating out integration tests from unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,15 @@ EXTRAGOARGS:=
 
 all: build
 
-generate build clean test:
+test: all-tests
+
+unit-tests:
+	go test -short $(EXTRAGOARGS)
+
+all-tests:
+	go test $(EXTRAGOARGS)
+
+generate build clean:
 	go $@ $(EXTRAGOARGS)
 
-.PHONY: all generate clean build test
+.PHONY: all generate clean build test unit-tests all-tests

--- a/machine_test.go
+++ b/machine_test.go
@@ -76,6 +76,10 @@ func TestNewMachine(t *testing.T) {
 }
 
 func TestMicroVMExecution(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	var nCpus int64 = 2
 	cpuTemplate := models.CPUTemplate(models.CPUTemplateT2)
 	var memSz int64 = 256


### PR DESCRIPTION
This change makes modification to separate out integration tests from
unit tests. This makes it a little nicer to run only unit tests when
developing and finally running integration as a last check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
