### PR TITLE
Adds support for PatchGuestDriveByID to the FirecrackerClient

### DIFF
--- a/firecracker.go
+++ b/firecracker.go
@@ -126,6 +126,14 @@ func (f *FirecrackerClient) PutGuestVsockByID(ctx context.Context, vsockID strin
 	return f.client.Operations.PutGuestVsockByID(params)
 }
 
+func (f *FirecrackerClient) PatchGuestDriveByID(ctx context.Context, driveID string, drive *models.PartialDrive) (*ops.PatchGuestDriveByIDNoContent, error) {
+	params := ops.NewPatchGuestDriveByIDParamsWithContext(ctx)
+	params.SetBody(drive)
+	params.SetDriveID(driveID)
+
+	return f.client.Operations.PatchGuestDriveByID(params)
+}
+
 func (f *FirecrackerClient) CreateSyncAction(ctx context.Context, info *models.InstanceActionInfo) (*ops.CreateSyncActionNoContent, error) {
 	params := ops.NewCreateSyncActionParams()
 	params.SetContext(ctx)


### PR DESCRIPTION
*Issue #, if available:*
#39 : https://github.com/firecracker-microvm/firecracker-go-sdk/issues/39

*Description of changes:*
The generated clients support it so the wrapper client should support the operation as well.  
Not adding the operation to the machine.go as part of this change


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
