### PR TITLE
client: fixing test bug with hanging requests

### DIFF
--- a/client/client_transports_test.go
+++ b/client/client_transports_test.go
@@ -1,42 +1,45 @@
 package client
 
 import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/firecracker-microvm/firecracker-go-sdk/client/operations"
 	"github.com/go-openapi/runtime"
 	"github.com/stretchr/testify/assert"
-	"net"
-	"testing"
-	"time"
 )
+
+const expectedEndpointPath = "/test-operation"
 
 func TestNewUnixSocketTransport(t *testing.T) {
 	done := make(chan bool)
 
-	expectedMessage := "PUT /logger HTTP/1.1\r\nHost: localhost\r\nUser-Agent: Go-http-client/1.1\r\nContent-Length: 0\r\nAccept: application/json\r\nContent-Type: application/json\r\nAccept-Encoding: gzip\r\n\r\n"
 	socketPath := "testingUnixSocket.sock"
-	addr, _ := net.ResolveUnixAddr("unix", socketPath)
-	listener, _ := net.ListenUnix("unix", addr)
-	defer listener.Close()
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		panic(err)
+	}
 
-	go func() {
-		conn, err := listener.AcceptUnix()
-		if err != nil {
-			t.Error(err)
-		}
+	server := http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, expectedEndpointPath, req.URL.String())
+			w.WriteHeader(http.StatusOK)
+			close(done)
+		}),
+	}
 
-		buf := make([]byte, 512)
-		nr, err := conn.Read(buf)
-		if err != nil {
-			return
-		}
-
-		data := string(buf[0:nr])
-		assert.Equal(t, expectedMessage, data, "expectedMessage received on socket is different than what was sent")
-		done <- true
+	go server.Serve(listener)
+	defer func() {
+		server.Shutdown(context.Background())
+		listener.Close()
+		os.Remove(socketPath)
 	}()
 
 	unixTransport := NewUnixSocketTransport(socketPath, nil, false)
-
 	unixTransport.Submit(testOperation())
 
 	select {
@@ -50,9 +53,10 @@ func testOperation() *runtime.ClientOperation {
 	return &runtime.ClientOperation{
 		ID:                 "putLogger",
 		Method:             "PUT",
-		PathPattern:        "/logger",
+		PathPattern:        expectedEndpointPath,
 		ProducesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http"},
 		Params:             operations.NewPutLoggerParams(),
+		Reader:             &operations.PutLoggerReader{},
 	}
 }


### PR DESCRIPTION
Fixing test bug with hanging requests

Prior tests caused the HTTP client to hang waiting for a response. This
will now properly write a response and closing the request.

Fixes #52

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
