### PR TITLE
add support for rate limiting

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -161,6 +161,11 @@ type NetworkInterface struct {
 	HostDevName string
 	// AllowMMDS makes the Firecracker MMDS available on this network interface.
 	AllowMDDS bool
+
+	// InRateLimiter limits the incoming bytes.
+	InRateLimiter *models.RateLimiter
+	// OutRateLimiter limits the outgoing bytes.
+	OutRateLimiter *models.RateLimiter
 }
 
 // VsockDevice represents a vsock connection between the host and the guest
@@ -473,6 +478,14 @@ func (m *Machine) createNetworkInterface(ctx context.Context, iface NetworkInter
 		GuestMac:          iface.MacAddress,
 		HostDevName:       iface.HostDevName,
 		AllowMmdsRequests: iface.AllowMDDS,
+	}
+
+	if iface.InRateLimiter != nil {
+		ifaceCfg.RxRateLimiter = iface.InRateLimiter
+	}
+
+	if iface.OutRateLimiter != nil {
+		ifaceCfg.TxRateLimiter = iface.OutRateLimiter
 	}
 
 	resp, err := m.client.PutGuestNetworkInterfaceByID(ctx, ifaceID, &ifaceCfg)

--- a/rate_limiter.go
+++ b/rate_limiter.go
@@ -1,0 +1,58 @@
+package firecracker
+
+import (
+	"time"
+
+	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
+)
+
+// RateLimiterOpt represents a functional option for rate limiting construction
+type RateLimiterOpt func(*models.RateLimiter)
+
+// NewRateLimiter will construct a new RateLimiter with given parameters.
+func NewRateLimiter(bandwidth, ops models.TokenBucket, opts ...RateLimiterOpt) *models.RateLimiter {
+	limiter := &models.RateLimiter{
+		Bandwidth: &bandwidth,
+		Ops:       &ops,
+	}
+
+	for _, opt := range opts {
+		opt(limiter)
+	}
+
+	return limiter
+}
+
+// TokenBucketBuilder is a builder that allows of building components of the
+// models.RateLimiter structure.
+type TokenBucketBuilder struct {
+	bucket models.TokenBucket
+}
+
+// WithBucketSize will set the bucket size for the given token bucket
+func (b TokenBucketBuilder) WithBucketSize(size int64) TokenBucketBuilder {
+	b.bucket.Size = &size
+
+	return b
+}
+
+// WithRefillDuration will set the given refill duration of the bucket fill rate.
+func (b TokenBucketBuilder) WithRefillDuration(dur time.Duration) TokenBucketBuilder {
+	ms := dur.Nanoseconds()
+	ms /= int64(time.Millisecond)
+	b.bucket.RefillTime = &ms
+
+	return b
+}
+
+// WithInitialSize will set the initial token bucket size
+func (b TokenBucketBuilder) WithInitialSize(size int64) TokenBucketBuilder {
+	b.bucket.OneTimeBurst = &size
+
+	return b
+}
+
+// Build will return a new token bucket
+func (b TokenBucketBuilder) Build() models.TokenBucket {
+	return b.bucket
+}

--- a/rate_limiter_test.go
+++ b/rate_limiter_test.go
@@ -1,0 +1,54 @@
+package firecracker_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/firecracker-microvm/firecracker-go-sdk"
+	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateLimiter(t *testing.T) {
+	bucket := firecracker.TokenBucketBuilder{}.
+		WithRefillDuration(1 * time.Hour).
+		WithBucketSize(100).
+		WithInitialSize(100).
+		Build()
+
+	expectedBucket := models.TokenBucket{
+		OneTimeBurst: firecracker.Int64(100),
+		RefillTime:   firecracker.Int64(3600000),
+		Size:         firecracker.Int64(100),
+	}
+
+	assert.Equal(t, expectedBucket, bucket)
+}
+
+func TestRateLimiter_RefillTime(t *testing.T) {
+	cases := []struct {
+		Name                 string
+		Dur                  time.Duration
+		ExpectedMilliseconds int64
+	}{
+		{
+			Name:                 "one hour",
+			Dur:                  1 * time.Hour,
+			ExpectedMilliseconds: 3600000,
+		},
+		{
+			Name:                 "zero",
+			ExpectedMilliseconds: 0,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			bucket := firecracker.TokenBucketBuilder{}.
+				WithRefillDuration(c.Dur).
+				Build()
+
+			assert.Equal(t, &c.ExpectedMilliseconds, bucket.RefillTime)
+		})
+	}
+}


### PR DESCRIPTION
Adds support for rate limiting for inbound and outbound data streams of
firecracker. This also introduces a TokenBuilder which can be passed
into the NewRateLimiter factory function to return a new rate limiter.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
