### PR TITLE
Make machine.Wait() safe for multiple calls

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -134,17 +134,18 @@ func (cfg *Config) Validate() error {
 
 // Machine is the main object for manipulating Firecracker microVMs
 type Machine struct {
+	// Metadata is the associated metadata that will be sent to the firecracker
+	// process
+	Metadata interface{}
+	// Handlers holds the set of handlers that are run for validation and start
+	Handlers Handlers
+
 	cfg           Config
 	client        Firecracker
 	cmd           *exec.Cmd
 	logger        *log.Entry
 	machineConfig models.MachineConfiguration // The actual machine config as reported by Firecracker
-
-	// Metadata is the associated metadata that will be sent to the firecracker
-	// process
-	Metadata interface{}
-	errCh    chan error
-	Handlers Handlers
+	errCh         chan error
 }
 
 // Logger returns a logrus logger appropriate for logging hypervisor messages

--- a/machine.go
+++ b/machine.go
@@ -518,11 +518,6 @@ func (m *Machine) addVsock(ctx context.Context, dev VsockDevice) error {
 	return nil
 }
 
-// StartInstance starts the Firecracker microVM
-func (m *Machine) StartInstance(ctx context.Context) error {
-	return m.startInstance(ctx)
-}
-
 func (m *Machine) startInstance(ctx context.Context) error {
 	info := models.InstanceActionInfo{
 		ActionType: models.InstanceActionInfoActionTypeInstanceStart,

--- a/machine.go
+++ b/machine.go
@@ -320,7 +320,6 @@ func (m *Machine) startVMM(ctx context.Context) error {
 	}()
 
 	// Set up a signal handler and pass INT, QUIT, and TERM through to firecracker
-	vmchan := make(chan error)
 	sigchan := make(chan os.Signal)
 	signal.Notify(sigchan, os.Interrupt,
 		syscall.SIGQUIT,
@@ -329,13 +328,9 @@ func (m *Machine) startVMM(ctx context.Context) error {
 		syscall.SIGABRT)
 	m.logger.Debugf("Setting up signal handler")
 	go func() {
-		select {
-		case sig := <-sigchan:
-			m.logger.Printf("Caught signal %s", sig)
-			m.cmd.Process.Signal(sig)
-		case err = <-vmchan:
-			m.errCh <- err
-		}
+		sig := <-sigchan
+		m.logger.Printf("Caught signal %s", sig)
+		m.cmd.Process.Signal(sig)
 	}()
 
 	// Wait for firecracker to initialize:


### PR DESCRIPTION
*Description of changes:*
Prior to this change, multiple calls to `Wait()` could result in the error being lost, and for subsequent callers to wait until their context was canceled rather than waiting for the VMM to exit.  This change makes it such that multiple callers of `Wait()` will all block for the VMM exit (or their individual context cancellation) and will receive the same error (for non-canceled contexts).

This behavior was causing `TestMicroVMExecution` to take 30 seconds every time, which was the length of the `vmmCtx` timeout.  After this change, `TestMicroVMExecution` takes ~7 seconds, which is the length of the calls to `time.Sleep` in that test.

The other commits in this pull request are either in support of making `Wait()` safe (like enforcing that `Start()` can only be called once) or are cleaning up code.

Please view the commits individually to associate them with the change called out in the commit message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
