### PR TITLE
client: moves transport files to firecracker package

### DIFF
--- a/client_transports.go
+++ b/client_transports.go
@@ -1,4 +1,4 @@
-package client
+package firecracker
 
 import (
 	"context"
@@ -6,9 +6,10 @@ import (
 	"net"
 	"net/http"
 
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/sirupsen/logrus"
 
-	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/firecracker-microvm/firecracker-go-sdk/client"
 )
 
 // NewUnixSocketTransport creates a new clientTransport configured at the specified Unix socketPath.
@@ -24,7 +25,7 @@ func NewUnixSocketTransport(socketPath string, logger *logrus.Entry, debug bool)
 		},
 	}
 
-	transport := httptransport.New(DefaultHost, DefaultBasePath, DefaultSchemes)
+	transport := httptransport.New(client.DefaultHost, client.DefaultBasePath, client.DefaultSchemes)
 	transport.Transport = socketTransport
 
 	if debug {

--- a/client_transports_test.go
+++ b/client_transports_test.go
@@ -1,4 +1,4 @@
-package client
+package firecracker
 
 import (
 	"context"

--- a/firecracker.go
+++ b/firecracker.go
@@ -34,7 +34,7 @@ type FirecrackerClient struct {
 
 // NewFirecrackerClient creates a FirecrackerClient
 func NewFirecrackerClient(socketPath string, logger *logrus.Entry, debug bool) *FirecrackerClient {
-	unixTransport := client.NewUnixSocketTransport(socketPath, logger, debug)
+	unixTransport := NewUnixSocketTransport(socketPath, logger, debug)
 	firecracker := client.New(unixTransport, strfmt.NewFormats())
 
 	return &FirecrackerClient{client: firecracker}


### PR DESCRIPTION
Moves client/client_transports.go and client/client_transports_test.go
to the firecracker package due to generation deleting everything in the
client directory

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
