### PR TITLE
Fixes vetting issues

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -111,7 +111,7 @@ func ExampleDrivesBuilder() {
 	}
 }
 
-func ExampleDrivesBuilder_DriveOpt() {
+func ExampleDrivesBuilder_driveOpt() {
 	drives := firecracker.NewDrivesBuilder("/path/to/rootfs").
 		AddDrive("/path/to/drive1.img", true).
 		AddDrive("/path/to/drive2.img", false, func(drive *models.Drive) {
@@ -153,7 +153,7 @@ func ExampleDrivesBuilder_DriveOpt() {
 	}
 }
 
-func ExampleNetworkInterfaces_RateLimiting() {
+func ExampleNetworkInterface_rateLimiting() {
 	// construct the limitations of the bandwidth for firecracker
 	bandwidthBuilder := firecracker.TokenBucketBuilder{}.
 		WithInitialSize(1024 * 1024).        // Initial token amount

--- a/machine.go
+++ b/machine.go
@@ -189,17 +189,17 @@ type VsockDevice struct {
 
 // SocketPath returns the filesystem path to the socket used for VMM
 // communication
-func (m Machine) socketPath() string {
+func (m *Machine) socketPath() string {
 	return m.cfg.SocketPath
 }
 
 // LogFile returns the filesystem path of the VMM log
-func (m Machine) LogFile() string {
+func (m *Machine) LogFile() string {
 	return m.cfg.LogFifo
 }
 
 // LogLevel returns the VMM log level.
-func (m Machine) LogLevel() string {
+func (m *Machine) LogLevel() string {
 	return m.cfg.LogLevel
 }
 


### PR DESCRIPTION
Example names were not Go idiomatic along with some Machine method
copying locks which vet was complaining about.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
