### PR TITLE
Adding support for patch guest drive

### DIFF
--- a/firecracker.go
+++ b/firecracker.go
@@ -228,3 +228,27 @@ func (f *Client) GetMachineConfig(opts ...GetMachineConfigOpt) (*ops.GetMachineC
 
 	return f.client.Operations.GetMachineConfig(p)
 }
+
+// PatchGuestDriveByIDOpt is a functional option to be used for the PutMmds API in setting
+// any additional optional fields.
+type PatchGuestDriveByIDOpt func(*ops.PatchGuestDriveByIDParams)
+
+// PatchGuestDriveByID is a wrapper for the swagger generated client to make calling of the
+// API easier.
+func (f *Client) PatchGuestDriveByID(ctx context.Context, driveID, pathOnHost string, opts ...PatchGuestDriveByIDOpt) (*ops.PatchGuestDriveByIDNoContent, error) {
+	params := ops.NewPatchGuestDriveByIDParams()
+	params.SetContext(ctx)
+
+	partialDrive := models.PartialDrive{
+		DriveID:    &driveID,
+		PathOnHost: &pathOnHost,
+	}
+	params.SetBody(&partialDrive)
+	params.DriveID = driveID
+
+	for _, opt := range opts {
+		opt(params)
+	}
+
+	return f.client.Operations.PatchGuestDriveByID(params)
+}

--- a/machine.go
+++ b/machine.go
@@ -576,6 +576,18 @@ func (m *Machine) SetMetadata(ctx context.Context, metadata interface{}) error {
 	return nil
 }
 
+// UpdateGuestDrive will modify the current guest drive of ID index with the new
+// parameters of the partialDrive.
+func (m *Machine) UpdateGuestDrive(ctx context.Context, driveID, pathOnHost string, opts ...PatchGuestDriveByIDOpt) error {
+	if _, err := m.client.PatchGuestDriveByID(ctx, driveID, pathOnHost, opts...); err != nil {
+		m.logger.Errorf("PatchGuestDrive failed: %v", err)
+		return err
+	}
+
+	m.logger.Printf("PatchGuestDrive successful")
+	return nil
+}
+
 // refreshMachineConfig synchronizes our cached representation of the machine configuration
 // with that reported by the Firecracker API
 func (m *Machine) refreshMachineConfig() error {

--- a/machine_test.go
+++ b/machine_test.go
@@ -145,6 +145,7 @@ func TestMicroVMExecution(t *testing.T) {
 	t.Run("TestAttachSecondaryDrive", func(t *testing.T) { testAttachSecondaryDrive(ctx, t, m) })
 	t.Run("TestAttachVsock", func(t *testing.T) { testAttachVsock(ctx, t, m) })
 	t.Run("SetMetadata", func(t *testing.T) { testSetMetadata(ctx, t, m) })
+	t.Run("TestUpdateGuestDrive", func(t *testing.T) { testUpdateGuestDrive(vmmCtx, t, m) })
 	t.Run("TestStartInstance", func(t *testing.T) { testStartInstance(vmmCtx, t, m) })
 
 	// Let the VMM start and stabilize...
@@ -288,6 +289,13 @@ func testCreateBootSource(ctx context.Context, t *testing.T, m *Machine, vmlinux
 	err := m.createBootSource(ctx, vmlinuxPath, "ro console=ttyS0 noapic reboot=k panic=0 pci=off nomodules")
 	if err != nil {
 		t.Errorf("failed to create boot source: %s", err)
+	}
+}
+
+func testUpdateGuestDrive(ctx context.Context, t *testing.T, m *Machine) {
+	path := filepath.Join(testDataPath, "drive-3.img")
+	if err := m.UpdateGuestDrive(ctx, "2", path); err != nil {
+		t.Errorf("unexpected error on swapping guest drive: %v", err)
 	}
 }
 


### PR DESCRIPTION
Introduces a new method on `Machine` called `UpdateGuestDrive`, which will allow patching a given guest drive's path. If firecracker ever adds additional fields that can be patched, the `PatchGuestDriveByIDOpt` can be used to set the newly introduced fields.

Fixes #39 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
