### PR TITLE
fix field name typo AllowMDDS -> AllowMDDS

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -156,7 +156,7 @@ type NetworkInterface struct {
 	// HostDevName defines the file path of the tap device on the host.
 	HostDevName string
 	// AllowMMDS makes the Firecracker MMDS available on this network interface.
-	AllowMDDS bool
+	AllowMMDS bool
 
 	// InRateLimiter limits the incoming bytes.
 	InRateLimiter *models.RateLimiter
@@ -490,7 +490,7 @@ func (m *Machine) createNetworkInterface(ctx context.Context, iface NetworkInter
 		IfaceID:           &ifaceID,
 		GuestMac:          iface.MacAddress,
 		HostDevName:       iface.HostDevName,
-		AllowMmdsRequests: iface.AllowMDDS,
+		AllowMmdsRequests: iface.AllowMMDS,
 	}
 
 	if iface.InRateLimiter != nil {


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* The field should be named AllowMMDS in the NetworkConfiguration to reflect
the name in Firecracker swagger model.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
