### PR TITLE
.buildkite: clean up taps after test failure

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,6 +17,11 @@ steps:
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
 
+  - label: ':linux: setup taps'
+    commands:
+      - 'sudo ip tuntap add fc-test-tap${BUILDKITE_BUILD_NUMBER} mode tap user $(sudo id -u buildkite-agent)'
+      - 'sudo ip tuntap add fc-root-tap${BUILDKITE_BUILD_NUMBER} mode tap user $(sudo id -u buildkite-agent)'
+
   # We use a "wait" step here, because Go's module logic freaks out when
   # multiple go builds are downloading to the same cache.
   - wait
@@ -31,17 +36,23 @@ steps:
       - 'ln -s /var/lib/fc-ci/vmlinux.bin testdata/vmlinux'
       - 'ln -s /usr/local/bin/firecracker-v0.15.0 testdata/firecracker'
       - 'ln -s /usr/local/bin/jailer-v0.15.0 testdata/jailer'
-      - 'sudo ip tuntap add fc-test-tap${BUILDKITE_BUILD_NUMBER} mode tap user $(sudo id -u buildkite-agent)'
       - "DISABLE_ROOT_TESTS=true FC_TEST_TAP=fc-test-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1'"
-      - 'sudo ip tuntap del fc-test-tap${BUILDKITE_BUILD_NUMBER} mode tap'
 
   - label: ':hammer: root tests'
     commands:
       - 'ln -s /var/lib/fc-ci/vmlinux.bin testdata/vmlinux'
       - 'cp /usr/local/bin/firecracker-v0.15.0 testdata/firecracker'
       - 'cp /usr/local/bin/jailer-v0.15.0 testdata/jailer'
-      - 'sudo ip tuntap add fc-root-tap${BUILDKITE_BUILD_NUMBER} mode tap user $(sudo id -u buildkite-agent)'
       - "sudo FC_TEST_TAP=fc-root-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1'"
-      - 'sudo ip tuntap del fc-root-tap${BUILDKITE_BUILD_NUMBER} mode tap'
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
+
+  # This allows the cleanup step to always run, regardless of test failure
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ':linux: cleanup taps'
+    commands:
+      - 'sudo ip tuntap del fc-test-tap${BUILDKITE_BUILD_NUMBER} mode tap'
+      - 'sudo ip tuntap del fc-root-tap${BUILDKITE_BUILD_NUMBER} mode tap'
+


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/firecracker-microvm/firecracker-go-sdk/issues/73

*Description of changes:*
tap removal now completes regardless of whether the tests fail

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
