### PR TITLE
Add support for SendCtrlAltDel action

### DIFF
--- a/client/models/instance_action_info.go
+++ b/client/models/instance_action_info.go
@@ -33,7 +33,7 @@ import (
 type InstanceActionInfo struct {
 
 	// Enumeration indicating what type of action is contained in the payload
-	// Enum: [BlockDeviceRescan InstanceStart InstanceHalt]
+	// Enum: [BlockDeviceRescan InstanceStart InstanceHalt SendCtrlAltDel]
 	ActionType string `json:"action_type,omitempty"`
 
 	// payload
@@ -58,7 +58,7 @@ var instanceActionInfoTypeActionTypePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["BlockDeviceRescan","InstanceStart","InstanceHalt"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["BlockDeviceRescan","InstanceStart","InstanceHalt","SendCtrlAltDel"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -76,6 +76,9 @@ const (
 
 	// InstanceActionInfoActionTypeInstanceHalt captures enum value "InstanceHalt"
 	InstanceActionInfoActionTypeInstanceHalt string = "InstanceHalt"
+
+	// InstanceActionInfoActionTypeSendCtrlAltDel captures enum value "SendCtrlAltDel"
+	InstanceActionInfoActionTypeSendCtrlAltDel string = "SendCtrlAltDel"
 )
 
 // prop value enum

--- a/client/swagger.yaml
+++ b/client/swagger.yaml
@@ -401,6 +401,7 @@ definitions:
         - BlockDeviceRescan
         - InstanceStart
         - InstanceHalt
+        - SendCtrlAltDel
       payload:
         type: string
 


### PR DESCRIPTION
Updated the Swagger client definition to include the action for
SendCtrlAltDel action.

*Issue #, if available:*
https://github.com/firecracker-microvm/firectl/issues/16
https://github.com/firecracker-microvm/firecracker/pull/907

*Description of changes:*
Updated Swagger config to include the action for SendCtrlAltDel

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
