### PR TITLE
Fix coding error in NewSetMetadataHandler

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -173,7 +173,7 @@ func NewSetMetadataHandler(metadata interface{}) Handler {
 	return Handler{
 		Name: SetMetadataHandlerName,
 		Fn: func(ctx context.Context, m *Machine) error {
-			return m.SetMetadata(ctx, m.Metadata)
+			return m.SetMetadata(ctx, metadata)
 		},
 	}
 }


### PR DESCRIPTION
121ef9ac introduced Firecracker MMDS support, but included a bug that prevented
it from actually setting the given MMDS value.

Signed-off-by: Noah Meyerhans <nmeyerha@amazon.com>

*Issue #77 

Fix the coding error described in #77. Fix can be confirmed using the same firectl command line as shown in that issue:

```
$ ./firectl --kernel ~/bin/vmlinux --root-drive ~/src/firecracker/images/rootfs.img \
  -d --metadata='{"my_key":"xyz"}' --tap-device=fc-test-tap0/6a:11:48:21:1a:d5
...
DEBU[0000] Running handler fcinit.SetMetadata           
DEBU[0000] PUT /mmds HTTP/1.1
Host: localhost
User-Agent: Go-http-client/1.1
Content-Length: 17
Accept: application/json
Content-Type: application/json
Accept-Encoding: gzip

{"my_key":"xyz"}
 
DEBU[0000] HTTP/1.1 204 No Content
Content-Length: 0
Date: Thu, 28 Feb 2019 19:19:41 GMT

 
INFO[0000] SetMetadata successful                       
...
INFO[0000] startInstance successful: [PUT /actions][204] createSyncActionNoContent
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
