### PR TITLE
Wrap the CtrlAltDel API in a machine.Shutdown() method

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -260,6 +260,12 @@ func (m *Machine) Start(ctx context.Context) error {
 	return m.startInstance(ctx)
 }
 
+// Shutdown requests a clean shutdown of the VM by sending CtrlAltDelete on the virtual keyboard
+func (m *Machine) Shutdown(ctx context.Context) error {
+	m.logger.Debug("Called machine.Shutdown()")
+	return m.sendCtrlAltDel(ctx)
+}
+
 // Wait will wait until the firecracker process has finished.  Wait is safe to
 // call concurrently, and will deliver the same error to all callers, subject to
 // each caller's context cancellation.
@@ -567,6 +573,20 @@ func (m *Machine) startInstance(ctx context.Context) error {
 		m.logger.Printf("startInstance successful: %s", resp.Error())
 	} else {
 		m.logger.Errorf("Starting instance: %s", err)
+	}
+	return err
+}
+
+func (m *Machine) sendCtrlAltDel(ctx context.Context) error {
+	info := models.InstanceActionInfo{
+		ActionType: models.InstanceActionInfoActionTypeSendCtrlAltDel,
+	}
+
+	resp, err := m.client.CreateSyncAction(ctx, &info)
+	if err == nil {
+		m.logger.Printf("Sent instance shutdown request: %s", resp.Error())
+	} else {
+		m.logger.Errorf("Unable to send CtrlAltDel: %s", err)
 	}
 	return err
 }

--- a/machine_test.go
+++ b/machine_test.go
@@ -140,7 +140,7 @@ func TestJailerMicroVMExecution(t *testing.T) {
 	jailerFullRootPath := filepath.Join(jailerTestPath, "firecracker", id)
 	os.MkdirAll(jailerTestPath, 0777)
 
-	socketPath := filepath.Join(jailerTestPath, "firecracker", "api.socket")
+	socketPath := filepath.Join(jailerTestPath, "firecracker", "TestJailerMicroVMExecution.socket")
 	logFifo := filepath.Join(testDataPath, "firecracker.log")
 	metricsFifo := filepath.Join(testDataPath, "firecracker-metrics")
 	defer func() {
@@ -257,7 +257,7 @@ func TestMicroVMExecution(t *testing.T) {
 	var nCpus int64 = 2
 	cpuTemplate := models.CPUTemplate(models.CPUTemplateT2)
 	var memSz int64 = 256
-	socketPath := filepath.Join(testDataPath, "firecracker.sock")
+	socketPath := filepath.Join(testDataPath, "TestMicroVMExecution.sock")
 	logFifo := filepath.Join(testDataPath, "firecracker.log")
 	metricsFifo := filepath.Join(testDataPath, "firecracker-metrics")
 	defer func() {
@@ -338,7 +338,7 @@ func TestMicroVMExecution(t *testing.T) {
 }
 
 func TestStartVMM(t *testing.T) {
-	socketPath := filepath.Join("testdata", "fc-start-vmm-test.sock")
+	socketPath := filepath.Join("testdata", "TestStartVMM.sock")
 	defer os.Remove(socketPath)
 	cfg := Config{
 		SocketPath: socketPath,
@@ -373,7 +373,7 @@ func TestStartVMM(t *testing.T) {
 }
 
 func TestStartVMMOnce(t *testing.T) {
-	socketPath := filepath.Join("testdata", "fc-start-vmm-test.sock")
+	socketPath := filepath.Join("testdata", "TestStartVMMOnce.sock")
 	defer os.Remove(socketPath)
 
 	cfg := Config{

--- a/machine_test.go
+++ b/machine_test.go
@@ -330,7 +330,7 @@ func TestMicroVMExecution(t *testing.T) {
 	timer := time.NewTimer(5 * time.Second)
 	select {
 	case <-timer.C:
-		t.Run("TestStopVMM", func(t *testing.T) { testStopVMM(ctx, t, m) })
+		t.Run("TestShutdown", func(t *testing.T) { testShutdown(vmmCtx, t, m) })
 	case <-exitchannel:
 		// if we've already exited, there's no use waiting for the timer
 	}
@@ -370,7 +370,6 @@ func TestStartVMM(t *testing.T) {
 			t.Errorf("startVMM returned %s", m.Wait(ctx))
 		}
 	}
-
 }
 
 func TestStartVMMOnce(t *testing.T) {
@@ -410,6 +409,7 @@ func TestStartVMMOnce(t *testing.T) {
 	case <-timeout.Done():
 		if timeout.Err() == context.DeadlineExceeded {
 			t.Log("firecracker ran for 250ms")
+			t.Run("TestStopVMM", func(t *testing.T) { testStopVMM(ctx, t, m) })
 		} else {
 			t.Errorf("startVMM returned %s", m.Wait(ctx))
 		}
@@ -562,6 +562,13 @@ func testStopVMM(ctx context.Context, t *testing.T, m *Machine) {
 	err := m.StopVMM()
 	if err != nil {
 		t.Errorf("StopVMM failed: %s", err)
+	}
+}
+
+func testShutdown(ctx context.Context, t *testing.T, m *Machine) {
+	err := m.Shutdown(ctx)
+	if err != nil {
+		t.Errorf("machine.Shutdown() failed: %s", err)
 	}
 }
 

--- a/machine_test.go
+++ b/machine_test.go
@@ -323,17 +323,20 @@ func TestMicroVMExecution(t *testing.T) {
 	t.Run("TestAttachSecondaryDrive", func(t *testing.T) { testAttachSecondaryDrive(ctx, t, m) })
 	t.Run("TestAttachVsock", func(t *testing.T) { testAttachVsock(ctx, t, m) })
 	t.Run("SetMetadata", func(t *testing.T) { testSetMetadata(ctx, t, m) })
-	t.Run("TestUpdateGuestDrive", func(t *testing.T) { testUpdateGuestDrive(vmmCtx, t, m) })
-	t.Run("TestStartInstance", func(t *testing.T) { testStartInstance(vmmCtx, t, m) })
+	t.Run("TestUpdateGuestDrive", func(t *testing.T) { testUpdateGuestDrive(ctx, t, m) })
+	t.Run("TestStartInstance", func(t *testing.T) { testStartInstance(ctx, t, m) })
 
 	// Let the VMM start and stabilize...
 	timer := time.NewTimer(5 * time.Second)
 	select {
 	case <-timer.C:
-		t.Run("TestShutdown", func(t *testing.T) { testShutdown(vmmCtx, t, m) })
+		t.Run("TestShutdown", func(t *testing.T) { testShutdown(ctx, t, m) })
 	case <-exitchannel:
 		// if we've already exited, there's no use waiting for the timer
 	}
+	// unconditionally stop the VM here. TestShutdown may have triggered a shutdown, but if it
+	// didn't for some reason, we still need to terminate it:
+	m.StopVMM()
 	m.Wait(vmmCtx)
 }
 


### PR DESCRIPTION
#72 added firecracker 0.15.0 API support to the generated client. This change introduces a machine.Shutdown() method to wrap that generated API.

It also includes some improvements to tests to help with consistency and debuggability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
