### PR TITLE
Update changelog for 0.15.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.15.1
+
+* Add the machine.Shutdown() method, enabling access to the SendCtrlAltDel API
+  added in Firecracker 0.15.0
+
 # 0.15.0
 
 * Initial release

--- a/version.go
+++ b/version.go
@@ -14,4 +14,4 @@
 package firecracker
 
 // Version represents the current version of the SDK.
-const Version = "0.15.0"
+const Version = "0.15.1"


### PR DESCRIPTION
Signed-off-by: Noah Meyerhans <nmeyerha@amazon.com>

*Description of changes:*

As discussed in firecracker-microvm/firectl#24, the SDK did not include a wrapper for the `SendCtrlAltDel` Firecracker API with the 0.15.0 release. We've since added support for that API in #81 as the `machine.Shutdown()` method and should release a 0.15.1 version of the SDK including this change.

This PR prepares for that release by updating the changelog.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
