### PR TITLE
Fixes bug where default socket path would be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [ Unreleased ]
+
+* Fixes bug where default socketpath would always be used when not using jailer (#84)
+
 # 0.15.1
 
 * Add the machine.Shutdown() method, enabling access to the SendCtrlAltDel API

--- a/machine.go
+++ b/machine.go
@@ -216,7 +216,7 @@ func NewMachine(ctx context.Context, cfg Config, opts ...Opt) (*Machine, error) 
 	} else {
 		m.Handlers.Validation = m.Handlers.Validation.Append(ConfigValidationHandler)
 		m.cmd = defaultFirecrackerVMMCommandBuilder.
-			WithSocketPath(m.cfg.SocketPath).
+			WithSocketPath(cfg.SocketPath).
 			Build(ctx)
 	}
 

--- a/machine_test.go
+++ b/machine_test.go
@@ -756,6 +756,31 @@ func TestCaptureFifoToFile(t *testing.T) {
 	}
 }
 
+func TestSocketPathSet(t *testing.T) {
+	socketpath := "foo/bar"
+	m, err := NewMachine(context.Background(), Config{SocketPath: socketpath})
+	if err != nil {
+		t.Fatalf("Failed to create machine: %v", err)
+	}
+
+	found := false
+	for i := 0; i < len(m.cmd.Args); i++ {
+		if m.cmd.Args[i] != "--api-sock" {
+			continue
+		}
+
+		found = true
+		if m.cmd.Args[i+1] != socketpath {
+			t.Errorf("Incorrect socket path: %v", m.cmd.Args[i+1])
+		}
+		break
+	}
+
+	if !found {
+		t.Errorf("Failed to find socket path")
+	}
+}
+
 func copyFile(src, dst string, uid, gid int) error {
 	srcFd, err := os.Open(src)
 	if err != nil {


### PR DESCRIPTION
Due to using an empty value, this would cause Firecracker to use their
default socket path which is /tmp/firecracker.socket. This change uses
the config that actually has the socket path value

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
