### PR TITLE
Fix goswagger network timeouts during client generation

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -16,8 +16,8 @@
 // --skip-validation is used in the command-lines below to remove the network dependency that the swagger generator has
 // in attempting to validate that the email address specified in the yaml file is valid.
 
-//go:generate docker run --rm --net=none -v $PWD:/work -w /work quay.io/goswagger/swagger generate model -f ./client/swagger.yaml -T ./templates --model-package=client/models --client-package=client --copyright-file=COPYRIGHT_HEADER --skip-validation
-//go:generate docker run --rm --net=none -v $PWD:/work -w /work quay.io/goswagger/swagger generate client -f ./client/swagger.yaml -T ./templates --model-package=client/models --client-package=client --copyright-file=COPYRIGHT_HEADER --skip-validation
-//go:generate docker run --rm --net=none -v $PWD:/work -w /work quay.io/goswagger/swagger generate client -f ./client/swagger.yaml -C ./go_swagger_layout.yaml -T ./templates --model-package=client/models --client-package=fctesting --copyright-file=COPYRIGHT_HEADER --skip-validation
+//go:generate docker run --add-host github.com:127.1.1.1 --rm --net=none -v $PWD:/work -w /work quay.io/goswagger/swagger generate model -f ./client/swagger.yaml -T ./templates --model-package=client/models --client-package=client --copyright-file=COPYRIGHT_HEADER --skip-validation
+//go:generate docker run --add-host github.com:127.1.1.1 --rm --net=none -v $PWD:/work -w /work quay.io/goswagger/swagger generate client -f ./client/swagger.yaml -T ./templates --model-package=client/models --client-package=client --copyright-file=COPYRIGHT_HEADER --skip-validation
+//go:generate docker run --add-host github.com:127.1.1.1 --rm --net=none -v $PWD:/work -w /work quay.io/goswagger/swagger generate client -f ./client/swagger.yaml -C ./go_swagger_layout.yaml -T ./templates --model-package=client/models --client-package=fctesting --copyright-file=COPYRIGHT_HEADER --skip-validation
 
 package firecracker


### PR DESCRIPTION
The goswagger API client generator tries to access github.com repeatedly when
running. We're running with no network at all, so these requests are currently
timing out. (Why aren't they getting ENETUNREACH or similar?) This change adds
an entry to /etc/hosts in the container where we run goswagger to point
github.com at localhost, which results in a fast failure and significantly
reduces the time needed to generate the API client code.

For comparison, without this change:

```
$ git checkout master && time make generate
...
make generate  0.44s user 0.25s system 0% cpu 22:34.21 total
$ git checkout api-client-generator-really-really-has-no-network-and-i-mean-it && time make generate
...
make generate  0.40s user 0.24s system 4% cpu 14.327 total
```

22:34 versus 00:14.

Signed-off-by: Noah Meyerhans <nmeyerha@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
