### PR TITLE
Expose machine's PID

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -163,6 +163,14 @@ func (m *Machine) Logger() *log.Entry {
 	return m.logger.WithField("subsystem", userAgent)
 }
 
+// PID returns the machine's running process PID or an error if not running
+func (m *Machine) PID() (int, error) {
+	if m.cmd == nil || m.cmd.Process == nil {
+		return 0, fmt.Errorf("machine is not running")
+	}
+	return m.cmd.Process.Pid, nil
+}
+
 // NetworkInterface represents a Firecracker microVM's network interface.
 type NetworkInterface struct {
 	// MacAddress defines the MAC address that should be assigned to the network

--- a/machine.go
+++ b/machine.go
@@ -168,6 +168,11 @@ func (m *Machine) PID() (int, error) {
 	if m.cmd == nil || m.cmd.Process == nil {
 		return 0, fmt.Errorf("machine is not running")
 	}
+	select {
+	case <-m.exitCh:
+		return 0, fmt.Errorf("machine process has exited")
+	default:
+	}
 	return m.cmd.Process.Pid, nil
 }
 


### PR DESCRIPTION
*Description of changes:*

Access to the microvm's process PID is useful for getting process metrics as well as keeping state around. We're using scheduling software and knowing about the PID allows us to "reattach" the task.