### PR TITLE
Add UpdateGuestNetworkInterface

### DIFF
--- a/firecracker.go
+++ b/firecracker.go
@@ -141,6 +141,27 @@ func (f *Client) PutGuestNetworkInterfaceByID(ctx context.Context, ifaceID strin
 	return f.client.Operations.PutGuestNetworkInterfaceByID(cfg)
 }
 
+// PatchGuestNetworkInterfaceByIDOpt is a functional option to be used for the
+// PatchGuestNetworkInterfaceByID API in setting any additional optional fields.
+type PatchGuestNetworkInterfaceByIDOpt func(*ops.PatchGuestNetworkInterfaceByIDParams)
+
+// PatchGuestNetworkInterfaceByID is a wrapper for the swagger generated client to make calling of the
+// API easier.
+func (f *Client) PatchGuestNetworkInterfaceByID(ctx context.Context, ifaceID string, ifaceCfg *models.PartialNetworkInterface, opts ...PatchGuestNetworkInterfaceByIDOpt) (*ops.PatchGuestNetworkInterfaceByIDNoContent, error) {
+	timeout, cancel := context.WithTimeout(ctx, firecrackerRequestTimeout)
+	defer cancel()
+
+	cfg := ops.NewPatchGuestNetworkInterfaceByIDParamsWithContext(timeout)
+	cfg.SetBody(ifaceCfg)
+	cfg.SetIfaceID(ifaceID)
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return f.client.Operations.PatchGuestNetworkInterfaceByID(cfg)
+}
+
 // PutGuestDriveByIDOpt is a functional option to be used for the
 // PutGuestDriveByID API in setting any additional optional fields.
 type PutGuestDriveByIDOpt func(*ops.PutGuestDriveByIDParams)

--- a/machine.go
+++ b/machine.go
@@ -564,6 +564,17 @@ func (m *Machine) createNetworkInterface(ctx context.Context, iface NetworkInter
 	return err
 }
 
+// UpdateGuestNetworkInterface modifies the current guest network interface of ID index
+func (m *Machine) UpdateGuestNetworkInterface(ctx context.Context, ifaceID string, iface models.PartialNetworkInterface, opts ...PatchGuestNetworkInterfaceByIDOpt) error {
+	if _, err := m.client.PatchGuestNetworkInterfaceByID(ctx, ifaceID, &iface, opts...); err != nil {
+		m.logger.Errorf("Update network interface failed: %s: %v", ifaceID, err)
+		return err
+	}
+
+	m.logger.Infof("Updated network interface: %s", ifaceID)
+	return nil
+}
+
 // attachDrive attaches a secondary block device
 func (m *Machine) attachDrive(ctx context.Context, dev models.Drive) error {
 	hostPath := StringValue(dev.PathOnHost)

--- a/machine_test.go
+++ b/machine_test.go
@@ -499,7 +499,13 @@ func testUpdateGuestDrive(ctx context.Context, t *testing.T, m *Machine) {
 }
 
 func testUpdateGuestNetworkInterface(ctx context.Context, t *testing.T, m *Machine) {
-	if err := m.UpdateGuestNetworkInterface(ctx, "1", models.PartialNetworkInterface{IfaceID: String("1")}); err != nil {
+	rateLimitSet := RateLimiterSet{
+		InRateLimiter: NewRateLimiter(
+			TokenBucketBuilder{}.WithBucketSize(10).WithRefillDuration(10).Build(),
+			TokenBucketBuilder{}.WithBucketSize(10).WithRefillDuration(10).Build(),
+		),
+	}
+	if err := m.UpdateGuestNetworkInterfaceRateLimit(ctx, "1", rateLimitSet); err != nil {
 		t.Fatalf("Failed to update the network interface %v", err)
 	}
 }

--- a/machine_test.go
+++ b/machine_test.go
@@ -275,6 +275,13 @@ func TestMicroVMExecution(t *testing.T) {
 
 	vmlinuxPath := getVmlinuxPath(t)
 
+	networkIfaces := []NetworkInterface{
+		{
+			MacAddress:  "01-23-45-67-89-AB-CD-EF",
+			HostDevName: "tap0",
+		},
+	}
+
 	cfg := Config{
 		SocketPath:  socketPath,
 		LogFifo:     logFifo,
@@ -288,6 +295,7 @@ func TestMicroVMExecution(t *testing.T) {
 		},
 		Debug:             true,
 		DisableValidation: true,
+		NetworkInterfaces: networkIfaces,
 	}
 
 	ctx := context.Background()
@@ -332,6 +340,7 @@ func TestMicroVMExecution(t *testing.T) {
 	t.Run("TestAttachVsock", func(t *testing.T) { testAttachVsock(ctx, t, m) })
 	t.Run("SetMetadata", func(t *testing.T) { testSetMetadata(ctx, t, m) })
 	t.Run("TestUpdateGuestDrive", func(t *testing.T) { testUpdateGuestDrive(ctx, t, m) })
+	t.Run("TestUpdateGuestNetworkInterface", func(t *testing.T) { testUpdateGuestNetworkInterface(ctx, t, m) })
 	t.Run("TestStartInstance", func(t *testing.T) { testStartInstance(ctx, t, m) })
 
 	// Let the VMM start and stabilize...
@@ -486,6 +495,12 @@ func testUpdateGuestDrive(ctx context.Context, t *testing.T, m *Machine) {
 	path := filepath.Join(testDataPath, "drive-3.img")
 	if err := m.UpdateGuestDrive(ctx, "2", path); err != nil {
 		t.Errorf("unexpected error on swapping guest drive: %v", err)
+	}
+}
+
+func testUpdateGuestNetworkInterface(ctx context.Context, t *testing.T, m *Machine) {
+	if err := m.UpdateGuestNetworkInterface(ctx, "1", models.PartialNetworkInterface{IfaceID: String("1")}); err != nil {
+		t.Fatalf("Failed to update the network interface %v", err)
 	}
 }
 

--- a/machineiface.go
+++ b/machineiface.go
@@ -15,6 +15,8 @@ package firecracker
 
 import (
 	"context"
+
+	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
 )
 
 // This ensures the interface method signatures match that of Machine
@@ -29,4 +31,5 @@ type MachineIface interface {
 	Wait(context.Context) error
 	SetMetadata(context.Context, interface{}) error
 	UpdateGuestDrive(context.Context, string, string, ...PatchGuestDriveByIDOpt) error
+	UpdateGuestNetworkInterface(context.Context, string, models.PartialNetworkInterface, ...PatchGuestNetworkInterfaceByIDOpt) error
 }

--- a/machineiface.go
+++ b/machineiface.go
@@ -15,8 +15,6 @@ package firecracker
 
 import (
 	"context"
-
-	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
 )
 
 // This ensures the interface method signatures match that of Machine
@@ -31,5 +29,5 @@ type MachineIface interface {
 	Wait(context.Context) error
 	SetMetadata(context.Context, interface{}) error
 	UpdateGuestDrive(context.Context, string, string, ...PatchGuestDriveByIDOpt) error
-	UpdateGuestNetworkInterface(context.Context, string, models.PartialNetworkInterface, ...PatchGuestNetworkInterfaceByIDOpt) error
+	UpdateGuestNetworkInterfaceRateLimit(context.Context, string, RateLimiterSet, ...PatchGuestNetworkInterfaceByIDOpt) error
 }


### PR DESCRIPTION
*Issue #, if available:*

#66

*Description of changes:*

While both Drive and NetworkInterface can have RateLimiters on creation,
updating RateLimiters is only supported by NetworkInterface
(via PartialNetworkInterface).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
