### PR TITLE
Make logrus' log level configurable via FC_TEST_LOG_LEVEL

### DIFF
--- a/fctesting/utils.go
+++ b/fctesting/utils.go
@@ -16,9 +16,12 @@ package fctesting
 import (
 	"os"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const rootDisableEnvName = "DISABLE_ROOT_TESTS"
+const logLevelEnvName = "FC_TEST_LOG_LEVEL"
 
 var rootDisabled bool
 
@@ -42,4 +45,25 @@ func RequiresRoot(t testing.TB) {
 			"run the tests with the %s environment variable set.",
 			rootDisableEnvName)
 	}
+}
+
+func newLogger() *log.Logger {
+	str := os.Getenv(logLevelEnvName)
+	if str != "" {
+		logLevel, err := log.ParseLevel(str)
+		if err != nil {
+			panic(err)
+		}
+		return &log.Logger{
+			Out:   os.Stdout,
+			Level: logLevel,
+		}
+	} else {
+		return log.New()
+	}
+}
+
+// NewLogEntry creates log.Entry. The level is specified by "FC_TEST_LOG_LEVEL" environment variable
+func NewLogEntry() *log.Entry {
+	return log.NewEntry(newLogger())
 }

--- a/fctesting/utils.go
+++ b/fctesting/utils.go
@@ -47,23 +47,23 @@ func RequiresRoot(t testing.TB) {
 	}
 }
 
-func newLogger() *log.Logger {
+func newLogger(t testing.TB) *log.Logger {
 	str := os.Getenv(logLevelEnvName)
-	if str != "" {
-		logLevel, err := log.ParseLevel(str)
-		if err != nil {
-			panic(err)
-		}
-		return &log.Logger{
-			Out:   os.Stdout,
-			Level: logLevel,
-		}
-	} else {
+	if str == "" {
 		return log.New()
+	}
+
+	logLevel, err := log.ParseLevel(str)
+	if err != nil {
+		t.Fatalf("Failed to parse '%s' as Log Level: %v", str, err)
+	}
+	return &log.Logger{
+		Out:   os.Stdout,
+		Level: logLevel,
 	}
 }
 
 // NewLogEntry creates log.Entry. The level is specified by "FC_TEST_LOG_LEVEL" environment variable
-func NewLogEntry() *log.Entry {
-	return log.NewEntry(newLogger())
+func NewLogEntry(t testing.TB) *log.Entry {
+	return log.NewEntry(newLogger(t))
 }

--- a/fctesting/utils.go
+++ b/fctesting/utils.go
@@ -55,7 +55,7 @@ func newLogger(t testing.TB) *log.Logger {
 
 	logLevel, err := log.ParseLevel(str)
 	if err != nil {
-		t.Fatalf("Failed to parse '%s' as Log Level: %v", str, err)
+		t.Fatalf("Failed to parse %q as Log Level: %v", str, err)
 	}
 	return &log.Logger{
 		Out:   os.Stdout,

--- a/firecracker_test.go
+++ b/firecracker_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
-	log "github.com/sirupsen/logrus"
+	"github.com/firecracker-microvm/firecracker-go-sdk/fctesting"
 )
 
 func TestClient(t *testing.T) {
@@ -42,7 +42,7 @@ func TestClient(t *testing.T) {
 		PathOnHost:   String(filepath.Join(testDataPath, "drive-2.img")),
 	}
 
-	client := NewClient(socketpath, log.NewEntry(log.New()), true)
+	client := NewClient(socketpath, fctesting.NewLogEntry(), true)
 	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, 250*time.Millisecond)
 	defer deadlineCancel()
 	if err := waitForAliveVMM(deadlineCtx, client); err != nil {

--- a/firecracker_test.go
+++ b/firecracker_test.go
@@ -42,7 +42,7 @@ func TestClient(t *testing.T) {
 		PathOnHost:   String(filepath.Join(testDataPath, "drive-2.img")),
 	}
 
-	client := NewClient(socketpath, fctesting.NewLogEntry(), true)
+	client := NewClient(socketpath, fctesting.NewLogEntry(t), true)
 	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, 250*time.Millisecond)
 	defer deadlineCancel()
 	if err := waitForAliveVMM(deadlineCtx, client); err != nil {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -148,7 +148,7 @@ func TestHandlerListRun(t *testing.T) {
 
 	ctx := context.Background()
 	m := &Machine{
-		logger: fctesting.NewLogEntry(),
+		logger: fctesting.NewLogEntry(t),
 	}
 	if err := h.Run(ctx, m); err != bazErr {
 		t.Errorf("expected an error, but received %v", err)
@@ -613,8 +613,8 @@ func TestHandlers(t *testing.T) {
 			// resetting called for the next test
 			called = ""
 
-			client := NewClient(socketpath, fctesting.NewLogEntry(), true, WithOpsClient(&c.Client))
-			m, err := NewMachine(ctx, c.Config, WithClient(client), WithLogger(fctesting.NewLogEntry()))
+			client := NewClient(socketpath, fctesting.NewLogEntry(t), true, WithOpsClient(&c.Client))
+			m, err := NewMachine(ctx, c.Config, WithClient(client), WithLogger(fctesting.NewLogEntry(t)))
 			if err != nil {
 				t.Fatalf("failed to create machine: %v", err)
 			}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -8,8 +8,6 @@ import (
 	"reflect"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
-
 	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
 	ops "github.com/firecracker-microvm/firecracker-go-sdk/client/operations"
 	"github.com/firecracker-microvm/firecracker-go-sdk/fctesting"
@@ -150,7 +148,7 @@ func TestHandlerListRun(t *testing.T) {
 
 	ctx := context.Background()
 	m := &Machine{
-		logger: log.NewEntry(log.New()),
+		logger: fctesting.NewLogEntry(),
 	}
 	if err := h.Run(ctx, m); err != bazErr {
 		t.Errorf("expected an error, but received %v", err)
@@ -615,8 +613,8 @@ func TestHandlers(t *testing.T) {
 			// resetting called for the next test
 			called = ""
 
-			client := NewClient(socketpath, log.NewEntry(log.New()), true, WithOpsClient(&c.Client))
-			m, err := NewMachine(ctx, c.Config, WithClient(client))
+			client := NewClient(socketpath, fctesting.NewLogEntry(), true, WithOpsClient(&c.Client))
+			m, err := NewMachine(ctx, c.Config, WithClient(client), WithLogger(fctesting.NewLogEntry()))
 			if err != nil {
 				t.Fatalf("failed to create machine: %v", err)
 			}

--- a/machine.go
+++ b/machine.go
@@ -420,10 +420,10 @@ func (m *Machine) StopVMM() error {
 
 func (m *Machine) stopVMM() error {
 	if m.cmd != nil && m.cmd.Process != nil {
-		log.Debug("stopVMM(): sending sigterm to firecracker")
+		m.logger.Debug("stopVMM(): sending sigterm to firecracker")
 		return m.cmd.Process.Signal(syscall.SIGTERM)
 	}
-	log.Debug("stopVMM(): no firecracker process running, not sending a signal")
+	m.logger.Debug("stopVMM(): no firecracker process running, not sending a signal")
 
 	// don't return an error if the process isn't even running
 	return nil
@@ -517,7 +517,7 @@ func (m *Machine) createMachine(ctx context.Context) error {
 	m.logger.Debug("PutMachineConfiguration returned")
 	err = m.refreshMachineConfiguration()
 	if err != nil {
-		log.Errorf("Unable to inspect Firecracker MachineConfiguration. Continuing anyway. %s", err)
+		m.logger.Errorf("Unable to inspect Firecracker MachineConfiguration. Continuing anyway. %s", err)
 	}
 	m.logger.Debug("createMachine returning")
 	return err
@@ -595,7 +595,7 @@ func (m *Machine) UpdateGuestNetworkInterfaceRateLimit(ctx context.Context, ifac
 // attachDrive attaches a secondary block device
 func (m *Machine) attachDrive(ctx context.Context, dev models.Drive) error {
 	hostPath := StringValue(dev.PathOnHost)
-	log.Infof("Attaching drive %s, slot %s, root %t.", hostPath, StringValue(dev.DriveID), BoolValue(dev.IsRootDevice))
+	m.logger.Infof("Attaching drive %s, slot %s, root %t.", hostPath, StringValue(dev.DriveID), BoolValue(dev.IsRootDevice))
 	respNoContent, err := m.client.PutGuestDriveByID(ctx, StringValue(dev.DriveID), &dev)
 	if err == nil {
 		m.logger.Printf("Attached drive %s: %s", hostPath, respNoContent.Error())

--- a/machine_test.go
+++ b/machine_test.go
@@ -86,7 +86,7 @@ func TestNewMachine(t *testing.T) {
 				ChrootStrategy: NewNaiveChrootStrategy("path", "kernel-image-path"),
 			},
 		},
-		WithLogger(fctesting.NewLogEntry()))
+		WithLogger(fctesting.NewLogEntry(t)))
 	if err != nil {
 		t.Fatalf("failed to create new machine: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestJailerMicroVMExecution(t *testing.T) {
 		WithStderr(os.Stderr).
 		Build(ctx)
 
-	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd), WithLogger(fctesting.NewLogEntry()))
+	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd), WithLogger(fctesting.NewLogEntry(t)))
 	if err != nil {
 		t.Fatalf("failed to create new machine: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestMicroVMExecution(t *testing.T) {
 		WithBin(getFirecrackerBinaryPath()).
 		Build(ctx)
 
-	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd), WithLogger(fctesting.NewLogEntry()))
+	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd), WithLogger(fctesting.NewLogEntry(t)))
 	if err != nil {
 		t.Fatalf("failed to create new machine: %v", err)
 	}
@@ -368,7 +368,7 @@ func TestStartVMM(t *testing.T) {
 		WithSocketPath(cfg.SocketPath).
 		WithBin(getFirecrackerBinaryPath()).
 		Build(ctx)
-	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd), WithLogger(fctesting.NewLogEntry()))
+	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd), WithLogger(fctesting.NewLogEntry(t)))
 	if err != nil {
 		t.Fatalf("failed to create new machine: %v", err)
 	}
@@ -416,7 +416,7 @@ func TestStartVMMOnce(t *testing.T) {
 		WithSocketPath(cfg.SocketPath).
 		WithBin(getFirecrackerBinaryPath()).
 		Build(ctx)
-	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd), WithLogger(fctesting.NewLogEntry()))
+	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd), WithLogger(fctesting.NewLogEntry(t)))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -626,7 +626,7 @@ func TestWaitForSocket(t *testing.T) {
 
 	m := Machine{
 		cfg:    Config{SocketPath: filename},
-		logger: fctesting.NewLogEntry(),
+		logger: fctesting.NewLogEntry(t),
 	}
 
 	go func() {
@@ -638,13 +638,13 @@ func TestWaitForSocket(t *testing.T) {
 	}()
 
 	// Socket file created, HTTP request succeeded
-	m.client = NewClient(filename, fctesting.NewLogEntry(), true, WithOpsClient(&okClient))
+	m.client = NewClient(filename, fctesting.NewLogEntry(t), true, WithOpsClient(&okClient))
 	if err := m.waitForSocket(500*time.Millisecond, errchan); err != nil {
 		t.Errorf("waitForSocket returned unexpected error %s", err)
 	}
 
 	// Socket file exists, HTTP request failed
-	m.client = NewClient(filename, fctesting.NewLogEntry(), true, WithOpsClient(&errClient))
+	m.client = NewClient(filename, fctesting.NewLogEntry(t), true, WithOpsClient(&errClient))
 	if err := m.waitForSocket(500*time.Millisecond, errchan); err != context.DeadlineExceeded {
 		t.Error("waitforSocket did not return an expected timeout error")
 	}
@@ -699,7 +699,7 @@ func TestLogFiles(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	client := NewClient("socket-path", fctesting.NewLogEntry(), true, WithOpsClient(&opClient))
+	client := NewClient("socket-path", fctesting.NewLogEntry(t), true, WithOpsClient(&opClient))
 
 	stdoutPath := filepath.Join(testDataPath, "stdout.log")
 	stderrPath := filepath.Join(testDataPath, "stderr.log")
@@ -728,7 +728,7 @@ func TestLogFiles(t *testing.T) {
 		cfg,
 		WithClient(client),
 		WithProcessRunner(cmd),
-		WithLogger(fctesting.NewLogEntry()),
+		WithLogger(fctesting.NewLogEntry(t)),
 	)
 	if err != nil {
 		t.Fatalf("failed to create new machine: %v", err)
@@ -779,7 +779,7 @@ func TestCaptureFifoToFile(t *testing.T) {
 		t.Fatalf("Failed to create fifo file: %v", err)
 	}
 
-	if err := captureFifoToFile(fctesting.NewLogEntry(), fifoPath, fifo); err != nil {
+	if err := captureFifoToFile(fctesting.NewLogEntry(t), fifoPath, fifo); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -874,7 +874,7 @@ func TestPID(t *testing.T) {
 		DisableValidation: true,
 	}
 
-	m, err := NewMachine(context.Background(), cfg)
+	m, err := NewMachine(context.Background(), cfg, WithLogger(fctesting.NewLogEntry(t)))
 	if err != nil {
 		t.Errorf("expected no error during create machine, but received %v", err)
 	}

--- a/machine_test.go
+++ b/machine_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/firecracker-microvm/firecracker-go-sdk/client/operations"
 	ops "github.com/firecracker-microvm/firecracker-go-sdk/client/operations"
 	"github.com/firecracker-microvm/firecracker-go-sdk/fctesting"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -86,7 +85,8 @@ func TestNewMachine(t *testing.T) {
 				ExecFile:       "/path/to/firecracker",
 				ChrootStrategy: NewNaiveChrootStrategy("path", "kernel-image-path"),
 			},
-		})
+		},
+		WithLogger(fctesting.NewLogEntry()))
 	if err != nil {
 		t.Fatalf("failed to create new machine: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestJailerMicroVMExecution(t *testing.T) {
 		WithStderr(os.Stderr).
 		Build(ctx)
 
-	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd))
+	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd), WithLogger(fctesting.NewLogEntry()))
 	if err != nil {
 		t.Fatalf("failed to create new machine: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestMicroVMExecution(t *testing.T) {
 		WithBin(getFirecrackerBinaryPath()).
 		Build(ctx)
 
-	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd))
+	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd), WithLogger(fctesting.NewLogEntry()))
 	if err != nil {
 		t.Fatalf("failed to create new machine: %v", err)
 	}
@@ -368,7 +368,7 @@ func TestStartVMM(t *testing.T) {
 		WithSocketPath(cfg.SocketPath).
 		WithBin(getFirecrackerBinaryPath()).
 		Build(ctx)
-	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd))
+	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd), WithLogger(fctesting.NewLogEntry()))
 	if err != nil {
 		t.Fatalf("failed to create new machine: %v", err)
 	}
@@ -416,7 +416,7 @@ func TestStartVMMOnce(t *testing.T) {
 		WithSocketPath(cfg.SocketPath).
 		WithBin(getFirecrackerBinaryPath()).
 		Build(ctx)
-	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd))
+	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd), WithLogger(fctesting.NewLogEntry()))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -625,7 +625,8 @@ func TestWaitForSocket(t *testing.T) {
 	errchan := make(chan error)
 
 	m := Machine{
-		cfg: Config{SocketPath: filename},
+		cfg:    Config{SocketPath: filename},
+		logger: fctesting.NewLogEntry(),
 	}
 
 	go func() {
@@ -637,13 +638,13 @@ func TestWaitForSocket(t *testing.T) {
 	}()
 
 	// Socket file created, HTTP request succeeded
-	m.client = NewClient(filename, log.NewEntry(log.New()), true, WithOpsClient(&okClient))
+	m.client = NewClient(filename, fctesting.NewLogEntry(), true, WithOpsClient(&okClient))
 	if err := m.waitForSocket(500*time.Millisecond, errchan); err != nil {
 		t.Errorf("waitForSocket returned unexpected error %s", err)
 	}
 
 	// Socket file exists, HTTP request failed
-	m.client = NewClient(filename, log.NewEntry(log.New()), true, WithOpsClient(&errClient))
+	m.client = NewClient(filename, fctesting.NewLogEntry(), true, WithOpsClient(&errClient))
 	if err := m.waitForSocket(500*time.Millisecond, errchan); err != context.DeadlineExceeded {
 		t.Error("waitforSocket did not return an expected timeout error")
 	}
@@ -698,7 +699,7 @@ func TestLogFiles(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	client := NewClient("socket-path", log.NewEntry(log.New()), true, WithOpsClient(&opClient))
+	client := NewClient("socket-path", fctesting.NewLogEntry(), true, WithOpsClient(&opClient))
 
 	stdoutPath := filepath.Join(testDataPath, "stdout.log")
 	stderrPath := filepath.Join(testDataPath, "stderr.log")
@@ -727,6 +728,7 @@ func TestLogFiles(t *testing.T) {
 		cfg,
 		WithClient(client),
 		WithProcessRunner(cmd),
+		WithLogger(fctesting.NewLogEntry()),
 	)
 	if err != nil {
 		t.Fatalf("failed to create new machine: %v", err)
@@ -777,7 +779,7 @@ func TestCaptureFifoToFile(t *testing.T) {
 		t.Fatalf("Failed to create fifo file: %v", err)
 	}
 
-	if err := captureFifoToFile(log.NewEntry(log.New()), fifoPath, fifo); err != nil {
+	if err := captureFifoToFile(fctesting.NewLogEntry(), fifoPath, fifo); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

It makes `go test` less noisy and helps us to find the usage of
the global default logger. Since Machine and Client take logrus.Entry,
they shouldn't use the default one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
