### PR TITLE
machine: stop signal listener

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -385,9 +385,10 @@ func (m *Machine) startVMM(ctx context.Context) error {
 		syscall.SIGABRT)
 	m.logger.Debugf("Setting up signal handler")
 	go func() {
-		sig := <-sigchan
-		m.logger.Printf("Caught signal %s", sig)
-		m.cmd.Process.Signal(sig)
+		if sig, ok := <-sigchan; ok {
+			m.logger.Printf("Caught signal %s", sig)
+			m.cmd.Process.Signal(sig)
+		}
 	}()
 
 	// Wait for firecracker to initialize:
@@ -407,6 +408,7 @@ func (m *Machine) startVMM(ctx context.Context) error {
 		}
 
 		signal.Stop(sigchan)
+		close(sigchan)
 		close(m.exitCh)
 	}()
 

--- a/machine.go
+++ b/machine.go
@@ -406,6 +406,7 @@ func (m *Machine) startVMM(ctx context.Context) error {
 			m.err = err
 		}
 
+		signal.Stop(sigchan)
 		close(m.exitCh)
 	}()
 


### PR DESCRIPTION
It should fix signal handlers, now after even after instances have been started before on [unik](https://github.com/solo-io/unik), it's possible to close it with CTRL+C.

I have tested it on older versions of this library used by unik.