### PR TITLE
Removes JailerEnable and changes JailerCfg to be a pointer

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -241,8 +241,7 @@ func ExampleJailerConfig_enablingJailer() {
 			HtEnabled:  firecracker.Bool(false),
 			MemSizeMib: firecracker.Int64(256),
 		},
-		EnableJailer: true,
-		JailerCfg: firecracker.JailerConfig{
+		JailerCfg: &firecracker.JailerConfig{
 			UID:            &uid,
 			GID:            &gid,
 			ID:             id,

--- a/handlers.go
+++ b/handlers.go
@@ -55,7 +55,7 @@ var ConfigValidationHandler = Handler{
 var JailerConfigValidationHandler = Handler{
 	Name: ValidateJailerCfgHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		if !m.cfg.EnableJailer {
+		if m.cfg.JailerCfg == nil {
 			return nil
 		}
 

--- a/jailer.go
+++ b/jailer.go
@@ -32,6 +32,12 @@ const (
 	rootfsFolderName = "root"
 )
 
+var (
+	// ErrMissingJailerConfig will occur when entering jailer logic but the
+	// jailer config had not been specified.
+	ErrMissingJailerConfig = fmt.Errorf("JailerConfig was not set for use.")
+)
+
 // SeccompLevelValue represents a secure computing level type.
 type SeccompLevelValue int
 
@@ -352,7 +358,7 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
 	return nil
 }
 
-func linkFileToRootFS(cfg JailerConfig, dst, src string) error {
+func linkFileToRootFS(cfg *JailerConfig, dst, src string) error {
 	if err := os.Link(src, dst); err != nil {
 		return err
 	}
@@ -366,6 +372,10 @@ func LinkFilesHandler(rootfs, kernelImageFileName string) Handler {
 	return Handler{
 		Name: LinkFilesToRootFSHandlerName,
 		Fn: func(ctx context.Context, m *Machine) error {
+			if m.cfg.JailerCfg == nil {
+				return ErrMissingJailerConfig
+			}
+
 			// copy kernel image to root fs
 			if err := linkFileToRootFS(
 				m.cfg.JailerCfg,

--- a/jailer_test.go
+++ b/jailer_test.go
@@ -149,7 +149,7 @@ func TestJail(t *testing.T) {
 				},
 			}
 			cfg := &Config{
-				JailerCfg: c.jailerCfg,
+				JailerCfg: &c.jailerCfg,
 			}
 			jail(context.Background(), m, cfg)
 

--- a/machine.go
+++ b/machine.go
@@ -90,12 +90,8 @@ type Config struct {
 	// validation of configuration performed by the SDK.
 	DisableValidation bool
 
-	// EnableJailer will enable the jailer. By enabling the jailer, root level
-	// permissions are required.
-	EnableJailer bool
-
 	// JailerCfg is configuration specific for the jailer process.
-	JailerCfg JailerConfig
+	JailerCfg *JailerConfig
 }
 
 // Validate will ensure that the required fields are set and that
@@ -235,7 +231,7 @@ func NewMachine(ctx context.Context, cfg Config, opts ...Opt) (*Machine, error) 
 
 	m.Handlers = defaultHandlers
 
-	if cfg.EnableJailer {
+	if cfg.JailerCfg != nil {
 		m.Handlers.Validation = m.Handlers.Validation.Append(JailerConfigValidationHandler)
 		if err := jail(ctx, m, &cfg); err != nil {
 			return nil, err

--- a/machine_test.go
+++ b/machine_test.go
@@ -77,14 +77,6 @@ func TestNewMachine(t *testing.T) {
 				CPUTemplate: models.CPUTemplate(models.CPUTemplateT2),
 				HtEnabled:   Bool(false),
 			},
-			JailerCfg: JailerConfig{
-				GID:            Int(100),
-				UID:            Int(100),
-				ID:             "my-micro-vm",
-				NumaNode:       Int(0),
-				ExecFile:       "/path/to/firecracker",
-				ChrootStrategy: NewNaiveChrootStrategy("path", "kernel-image-path"),
-			},
 		},
 		WithLogger(fctesting.NewLogEntry(t)))
 	if err != nil {
@@ -177,7 +169,7 @@ func TestJailerMicroVMExecution(t *testing.T) {
 				PathOnHost:   String(rootdrivePath),
 			},
 		},
-		JailerCfg: JailerConfig{
+		JailerCfg: &JailerConfig{
 			GID:            Int(jailerGID),
 			UID:            Int(jailerUID),
 			NumaNode:       Int(0),
@@ -186,7 +178,6 @@ func TestJailerMicroVMExecution(t *testing.T) {
 			ExecFile:       getFirecrackerBinaryPath(),
 			ChrootStrategy: NewNaiveChrootStrategy(jailerFullRootPath, vmlinuxPath),
 		},
-		EnableJailer: true,
 	}
 
 	if _, err := os.Stat(vmlinuxPath); err != nil {


### PR DESCRIPTION
This fix allows for a more intuitive design in letting users enable the
jailer.

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
