### PR TITLE
Expose config to allow for advanced handlers

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -46,7 +46,7 @@ var ConfigValidationHandler = Handler{
 	Name: ValidateCfgHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
 		// ensure that the configuration is valid for the FcInit handlers.
-		return m.cfg.Validate()
+		return m.Cfg.Validate()
 	},
 }
 
@@ -55,12 +55,12 @@ var ConfigValidationHandler = Handler{
 var JailerConfigValidationHandler = Handler{
 	Name: ValidateJailerCfgHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		if m.cfg.JailerCfg == nil {
+		if m.Cfg.JailerCfg == nil {
 			return nil
 		}
 
 		hasRoot := false
-		for _, drive := range m.cfg.Drives {
+		for _, drive := range m.Cfg.Drives {
 			if BoolValue(drive.IsRootDevice) {
 				hasRoot = true
 				break
@@ -71,27 +71,27 @@ var JailerConfigValidationHandler = Handler{
 			return fmt.Errorf("A root drive must be present in the drive list")
 		}
 
-		if m.cfg.JailerCfg.ChrootStrategy == nil {
+		if m.Cfg.JailerCfg.ChrootStrategy == nil {
 			return fmt.Errorf("ChrootStrategy cannot be nil")
 		}
 
-		if len(m.cfg.JailerCfg.ExecFile) == 0 {
+		if len(m.Cfg.JailerCfg.ExecFile) == 0 {
 			return fmt.Errorf("exec file must be specified when using jailer mode")
 		}
 
-		if len(m.cfg.JailerCfg.ID) == 0 {
+		if len(m.Cfg.JailerCfg.ID) == 0 {
 			return fmt.Errorf("id must be specified when using jailer mode")
 		}
 
-		if m.cfg.JailerCfg.GID == nil {
+		if m.Cfg.JailerCfg.GID == nil {
 			return fmt.Errorf("GID must be specified when using jailer mode")
 		}
 
-		if m.cfg.JailerCfg.UID == nil {
+		if m.Cfg.JailerCfg.UID == nil {
 			return fmt.Errorf("UID must be specified when using jailer mode")
 		}
 
-		if m.cfg.JailerCfg.NumaNode == nil {
+		if m.Cfg.JailerCfg.NumaNode == nil {
 			return fmt.Errorf("ID must be specified when using jailer mode")
 		}
 
@@ -112,8 +112,8 @@ var StartVMMHandler = Handler{
 var CreateLogFilesHandler = Handler{
 	Name: CreateLogFilesHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		logFifoPath := m.cfg.LogFifo
-		metricsFifoPath := m.cfg.MetricsFifo
+		logFifoPath := m.Cfg.LogFifo
+		metricsFifoPath := m.Cfg.MetricsFifo
 
 		if len(logFifoPath) == 0 || len(metricsFifoPath) == 0 {
 			// logging is disabled
@@ -160,7 +160,7 @@ var CreateMachineHandler = Handler{
 var CreateBootSourceHandler = Handler{
 	Name: CreateBootSourceHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		return m.createBootSource(ctx, m.cfg.KernelImagePath, m.cfg.KernelArgs)
+		return m.createBootSource(ctx, m.Cfg.KernelImagePath, m.Cfg.KernelArgs)
 	},
 }
 
@@ -169,7 +169,7 @@ var CreateBootSourceHandler = Handler{
 var AttachDrivesHandler = Handler{
 	Name: AttachDrivesHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		return m.attachDrives(ctx, m.cfg.Drives...)
+		return m.attachDrives(ctx, m.Cfg.Drives...)
 	},
 }
 
@@ -178,7 +178,7 @@ var AttachDrivesHandler = Handler{
 var CreateNetworkInterfacesHandler = Handler{
 	Name: CreateNetworkInterfacesHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		return m.createNetworkInterfaces(ctx, m.cfg.NetworkInterfaces...)
+		return m.createNetworkInterfaces(ctx, m.Cfg.NetworkInterfaces...)
 	},
 }
 
@@ -187,7 +187,7 @@ var CreateNetworkInterfacesHandler = Handler{
 var AddVsocksHandler = Handler{
 	Name: AddVsocksHandlerName,
 	Fn: func(ctx context.Context, m *Machine) error {
-		return m.addVsocks(ctx, m.cfg.VsockDevices...)
+		return m.addVsocks(ctx, m.Cfg.VsockDevices...)
 	},
 }
 
@@ -234,7 +234,7 @@ type Handlers struct {
 // into a single list and running.
 func (h Handlers) Run(ctx context.Context, m *Machine) error {
 	l := HandlerList{}
-	if !m.cfg.DisableValidation {
+	if !m.Cfg.DisableValidation {
 		l = l.Append(h.Validation.list...)
 	}
 

--- a/jailer.go
+++ b/jailer.go
@@ -35,7 +35,7 @@ const (
 var (
 	// ErrMissingJailerConfig will occur when entering jailer logic but the
 	// jailer config had not been specified.
-	ErrMissingJailerConfig = fmt.Errorf("JailerConfig was not set for use.")
+	ErrMissingJailerConfig = fmt.Errorf("jailer config was not set for use")
 )
 
 // SeccompLevelValue represents a secure computing level type.
@@ -372,52 +372,52 @@ func LinkFilesHandler(rootfs, kernelImageFileName string) Handler {
 	return Handler{
 		Name: LinkFilesToRootFSHandlerName,
 		Fn: func(ctx context.Context, m *Machine) error {
-			if m.cfg.JailerCfg == nil {
+			if m.Cfg.JailerCfg == nil {
 				return ErrMissingJailerConfig
 			}
 
 			// copy kernel image to root fs
 			if err := linkFileToRootFS(
-				m.cfg.JailerCfg,
+				m.Cfg.JailerCfg,
 				filepath.Join(rootfs, kernelImageFileName),
-				m.cfg.KernelImagePath,
+				m.Cfg.KernelImagePath,
 			); err != nil {
 				return err
 			}
 
 			// copy all drives to the root fs
-			for i, drive := range m.cfg.Drives {
+			for i, drive := range m.Cfg.Drives {
 				hostPath := StringValue(drive.PathOnHost)
 				driveFileName := filepath.Base(hostPath)
 
 				if err := linkFileToRootFS(
-					m.cfg.JailerCfg,
+					m.Cfg.JailerCfg,
 					filepath.Join(rootfs, driveFileName),
 					hostPath,
 				); err != nil {
 					return err
 				}
 
-				m.cfg.Drives[i].PathOnHost = String(driveFileName)
+				m.Cfg.Drives[i].PathOnHost = String(driveFileName)
 			}
 
-			m.cfg.KernelImagePath = kernelImageFileName
+			m.Cfg.KernelImagePath = kernelImageFileName
 
-			for _, fifoPath := range []*string{&m.cfg.LogFifo, &m.cfg.MetricsFifo} {
+			for _, fifoPath := range []*string{&m.Cfg.LogFifo, &m.Cfg.MetricsFifo} {
 				if fifoPath == nil || *fifoPath == "" {
 					continue
 				}
 
 				fileName := filepath.Base(*fifoPath)
 				if err := linkFileToRootFS(
-					m.cfg.JailerCfg,
+					m.Cfg.JailerCfg,
 					filepath.Join(rootfs, fileName),
 					*fifoPath,
 				); err != nil {
 					return err
 				}
 
-				if err := os.Chown(filepath.Join(rootfs, fileName), *m.cfg.JailerCfg.UID, *m.cfg.JailerCfg.GID); err != nil {
+				if err := os.Chown(filepath.Join(rootfs, fileName), *m.Cfg.JailerCfg.UID, *m.Cfg.JailerCfg.GID); err != nil {
 					return err
 				}
 

--- a/machine_test.go
+++ b/machine_test.go
@@ -616,7 +616,7 @@ func TestWaitForSocket(t *testing.T) {
 	errchan := make(chan error)
 
 	m := Machine{
-		cfg:    Config{SocketPath: filename},
+		Cfg:    Config{SocketPath: filename},
 		logger: fctesting.NewLogEntry(t),
 	}
 


### PR DESCRIPTION
Exposing the config allows for modification of the machine configuration
during the 'Start' method. An example usage of this is using a custom
jailer

Also fixes a linting issue for `ErrMissingJailerConfig`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
