### PR TITLE
Adding Prepend to HanderList

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -251,6 +251,13 @@ type HandlerList struct {
 	list []Handler
 }
 
+// Prepend will prepend a new set of handlers to the handler list
+func (l HandlerList) Prepend(handlers ...Handler) HandlerList {
+	l.list = append(handlers, l.list...)
+
+	return l
+}
+
 // Append will append a new handler to the handler list.
 func (l HandlerList) Append(handlers ...Handler) HandlerList {
 	l.list = append(l.list, handlers...)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -38,6 +38,31 @@ func TestHandlerListAppend(t *testing.T) {
 	}
 }
 
+func TestHandlerListPrepend(t *testing.T) {
+	h := HandlerList{}
+	h.Prepend(Handler{Name: "foo"})
+
+	if size := h.Len(); size != 0 {
+		t.Errorf("expected length to be '0', but received '%d'", size)
+	}
+
+	expectedNames := []string{
+		"foo",
+		"bar",
+		"baz",
+	}
+
+	for _, name := range expectedNames {
+		h = h.Prepend(Handler{Name: name})
+	}
+
+	for i, name := range expectedNames {
+		if e, a := name, h.list[len(h.list)-i-1].Name; e != a {
+			t.Errorf("expected %q, but received %q", e, a)
+		}
+	}
+}
+
 func TestHandlerListRemove(t *testing.T) {
 	h := HandlerList{}.Append(
 		Handler{


### PR DESCRIPTION
Prepend will allow for prepending to a given handler list adding
flexbility  to the handler list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
