### PR TITLE
Added GetMetadata function to Machine

### DIFF
--- a/firecracker.go
+++ b/firecracker.go
@@ -15,8 +15,9 @@ package firecracker
 
 import (
 	"context"
-	"github.com/go-openapi/strfmt"
 	"time"
+
+	"github.com/go-openapi/strfmt"
 
 	"github.com/sirupsen/logrus"
 
@@ -232,6 +233,39 @@ func (f *Client) PutMmds(ctx context.Context, metadata interface{}, opts ...PutM
 	}
 
 	return f.client.Operations.PutMmds(params)
+}
+
+// GetMmdsOpt is a functional option to be used for the GetMmds API in setting
+// any additional optional fields.
+type GetMmdsOpt func(*ops.GetMmdsParams)
+
+// GetMmds is a wrapper for the swagger generated client to make calling of the
+// API easier.
+func (f *Client) GetMmds(ctx context.Context, opts ...GetMmdsOpt) (*ops.GetMmdsOK, error) {
+	params := ops.NewGetMmdsParams()
+	params.SetContext(ctx)
+	for _, opt := range opts {
+		opt(params)
+	}
+
+	return f.client.Operations.GetMmds(params)
+}
+
+// PatchMmdsOpt is a functional option to be used for the GetMmds API in setting
+// any additional optional fields.
+type PatchMmdsOpt func(*ops.PatchMmdsParams)
+
+// PatchMmds is a wrapper for the swagger generated client to make calling of the
+// API easier.
+func (f *Client) PatchMmds(ctx context.Context, metadata interface{}, opts ...PatchMmdsOpt) (*ops.PatchMmdsNoContent, error) {
+	params := ops.NewPatchMmdsParams()
+	params.SetContext(ctx)
+	params.SetBody(metadata)
+	for _, opt := range opts {
+		opt(params)
+	}
+
+	return f.client.Operations.PatchMmds(params)
 }
 
 // GetMachineConfigurationOpt  is a functional option to be used for the

--- a/machine.go
+++ b/machine.go
@@ -15,6 +15,7 @@ package firecracker
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -657,6 +658,40 @@ func (m *Machine) SetMetadata(ctx context.Context, metadata interface{}) error {
 	}
 
 	m.logger.Printf("SetMetadata successful")
+	return nil
+}
+
+// UpdateMetadata patches the machine's metadata for MDDS
+func (m *Machine) UpdateMetadata(ctx context.Context, metadata interface{}) error {
+	if _, err := m.client.PatchMmds(ctx, metadata); err != nil {
+		m.logger.Errorf("Updating metadata: %s", err)
+		return err
+	}
+
+	m.logger.Printf("UpdateMetadata successful")
+	return nil
+}
+
+// GetMetadata gets the machine's metadata from MDDS and unmarshals it into v
+func (m *Machine) GetMetadata(ctx context.Context, v interface{}) error {
+	resp, err := m.client.GetMmds(ctx)
+	if err != nil {
+		m.logger.Errorf("Getting metadata: %s", err)
+		return err
+	}
+
+	payloadData, err := json.Marshal(resp.Payload)
+	if err != nil {
+		m.logger.Errorf("Getting metadata failed parsing payload: %s", err)
+		return err
+	}
+
+	if err := json.Unmarshal(payloadData, v); err != nil {
+		m.logger.Errorf("Getting metadata failed parsing payload: %s", err)
+		return err
+	}
+
+	m.logger.Printf("GetMetadata successful")
 	return nil
 }
 

--- a/machine_test.go
+++ b/machine_test.go
@@ -330,6 +330,8 @@ func TestMicroVMExecution(t *testing.T) {
 	t.Run("TestAttachSecondaryDrive", func(t *testing.T) { testAttachSecondaryDrive(ctx, t, m) })
 	t.Run("TestAttachVsock", func(t *testing.T) { testAttachVsock(ctx, t, m) })
 	t.Run("SetMetadata", func(t *testing.T) { testSetMetadata(ctx, t, m) })
+	t.Run("UpdateMetadata", func(t *testing.T) { testUpdateMetadata(ctx, t, m) })
+	t.Run("GetMetadata", func(t *testing.T) { testGetMetadata(ctx, t, m) }) // Should be after testSetMetadata and testUpdateMetadata
 	t.Run("TestUpdateGuestDrive", func(t *testing.T) { testUpdateGuestDrive(ctx, t, m) })
 	t.Run("TestUpdateGuestNetworkInterface", func(t *testing.T) { testUpdateGuestNetworkInterface(ctx, t, m) })
 	t.Run("TestStartInstance", func(t *testing.T) { testStartInstance(ctx, t, m) })
@@ -664,6 +666,28 @@ func testSetMetadata(ctx context.Context, t *testing.T, m *Machine) {
 	err := m.SetMetadata(ctx, metadata)
 	if err != nil {
 		t.Errorf("failed to set metadata: %s", err)
+	}
+}
+
+func testUpdateMetadata(ctx context.Context, t *testing.T, m *Machine) {
+	metadata := map[string]string{"patch_key": "patch_value"}
+	err := m.UpdateMetadata(ctx, metadata)
+	if err != nil {
+		t.Errorf("failed to set metadata: %s", err)
+	}
+}
+
+func testGetMetadata(ctx context.Context, t *testing.T, m *Machine) {
+	metadata := struct {
+		Key      string `json:"key"`
+		PatchKey string `json:"patch_key"`
+	}{}
+	if err := m.GetMetadata(ctx, &metadata); err != nil {
+		t.Errorf("failed to get metadata: %s", err)
+	}
+
+	if metadata.Key != "value" || metadata.PatchKey != "patch_value" {
+		t.Error("failed to get expected metadata values")
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*
Resolves #109

*Description of changes:*
Added a function `GetMetadata` function to the Machine to wrap the `GetMmds` of client. I had the function return a `map[string]interface{}`, I figured this was the path of least resistance to return the meta data and allow the caller to parse it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
