### PR TITLE
Fixed ticker leak in waitForSocket when starting a VM

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -723,9 +723,13 @@ func (m *Machine) refreshMachineConfiguration() error {
 // waitForSocket waits for the given file to exist
 func (m *Machine) waitForSocket(timeout time.Duration, exitchan chan error) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
 
 	ticker := time.NewTicker(10 * time.Millisecond)
+
+	defer func() {
+		cancel()
+		ticker.Stop()
+	}()
 
 	for {
 		select {


### PR DESCRIPTION
A colleague of mine (@garslo) found there was a ticker not being closed in waiting for a socket during VM start. We observed considerable CPU usage when 20+ Firecracker VMs were spun up on a single system.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
