### PR TITLE
Download publicly-available artifacts when possible

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,18 +35,16 @@ steps:
 
   - label: ':hammer: tests'
     commands:
-      - 'ln -s /var/lib/fc-ci/vmlinux.bin testdata/vmlinux'
+      - ./download-testdata.sh
       - 'ln -s /usr/local/bin/firecracker-v0.17.0 testdata/firecracker'
-      - 'ln -s /usr/local/bin/jailer-v0.17.0 testdata/jailer'
       - "DISABLE_ROOT_TESTS=true FC_TEST_TAP=fc-test-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1'"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
 
   - label: ':hammer: root tests'
     commands:
-      - 'ln -s /var/lib/fc-ci/vmlinux.bin testdata/vmlinux'
+      - ./download-testdata.sh
       - 'cp /usr/local/bin/firecracker-v0.17.0 testdata/firecracker'
-      - 'cp /usr/local/bin/jailer-v0.17.0 testdata/jailer'
       - "sudo FC_TEST_TAP=fc-root-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1'"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"

--- a/download-testdata.sh
+++ b/download-testdata.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+set -euo pipefail
+
+download_safe () {
+    url=$1
+    checksum=$2
+    dest=$3
+
+    if [[ -f "${dest}" ]]; then
+        sha256sum --check <<< "${checksum} ${dest}" && return 0
+    fi
+
+    temp=$(mktemp)
+    curl --silent --show-error --retry 3 --max-time 30 --location \
+         "${url}" \
+         --output "${temp}"
+
+    sha256sum --check <<< "${checksum} ${temp}"
+    mv "${temp}" "${dest}"
+}
+
+download_safe \
+    https://s3.amazonaws.com/spec.ccfc.min/img/hello/kernel/hello-vmlinux.bin \
+    882fa465c43ab7d92e31bd4167da3ad6a82cb9230f9b0016176df597c6014cef \
+    testdata/vmlinux
+
+download_safe \
+    https://github.com/firecracker-microvm/firecracker/releases/download/v0.17.0/jailer-v0.17.0 \
+    f4ae19403f785a3687ecf7f831c101e7a54b5962e25ae2bbe5d97ef75fc292da \
+    testdata/jailer
+chmod +x testdata/jailer


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

While GitHub's firecracker 0.17.0 binary cannot be used due to vsock,
0.18.0 would be able to use with the Go SDK off-the-shelf.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
