### PR TITLE
support 0.18's new vsock API

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,8 +47,8 @@ steps:
     commands:
       - 'ln -s /var/lib/fc-ci/vmlinux.bin testdata/vmlinux'
       - 'ln -s /var/lib/fc-ci/rootfs.ext4 testdata/root-drive.img'
-      - 'ln -s /usr/local/bin/firecracker-v0.17.0 testdata/firecracker'
-      - 'ln -s /usr/local/bin/jailer-v0.17.0 testdata/jailer'
+      - 'ln -s /usr/local/bin/firecracker-v0.18.0 testdata/firecracker'
+      - 'ln -s /usr/local/bin/jailer-v0.18.0 testdata/jailer'
       - "DISABLE_ROOT_TESTS=true FC_TEST_TAP=fc-test-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1'"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
@@ -57,8 +57,8 @@ steps:
     commands:
       - 'ln -s /var/lib/fc-ci/vmlinux.bin testdata/vmlinux'
       - 'ln -s /var/lib/fc-ci/rootfs.ext4 testdata/root-drive.img'
-      - 'cp /usr/local/bin/firecracker-v0.17.0 testdata/firecracker'
-      - 'cp /usr/local/bin/jailer-v0.17.0 testdata/jailer'
+      - 'cp /usr/local/bin/firecracker-v0.18.0 testdata/firecracker'
+      - 'cp /usr/local/bin/jailer-v0.18.0 testdata/jailer'
       - 'make -C cni install CNI_BIN_ROOT=$(pwd)/testdata/bin'
       - "sudo FC_TEST_TAP=fc-root-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1'"
     agents:

--- a/client/models/vsock.go
+++ b/client/models/vsock.go
@@ -26,17 +26,22 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// Vsock vsock
+// Vsock Defines a vsock device, backed by a set of Unix Domain Sockets, on the host side. For host-initiated connections, Firecracker will be listening on the Unix socket identified by the path `uds_path`. Firecracker will create this socket, bind and listen on it. Host-initiated connections will be performed by connection to this socket and issuing a connection forwarding request to the desired guest-side vsock port (i.e. `CONNECT 52\n`, to connect to port 52). For guest-initiated connections, Firecracker will expect host software to be bound and listening on Unix sockets at `uds_path_<PORT>`. E.g. "/path/to/host_vsock.sock_52" for port number 52.
 // swagger:model Vsock
 type Vsock struct {
 
 	// Guest Vsock CID
-	// Minimum: 3
-	GuestCid int64 `json:"guest_cid,omitempty"`
-
-	// id
 	// Required: true
-	ID *string `json:"id"`
+	// Minimum: 3
+	GuestCid *int64 `json:"guest_cid"`
+
+	// Path to UNIX domain socket, used to proxy vsock connections.
+	// Required: true
+	UdsPath *string `json:"uds_path"`
+
+	// vsock id
+	// Required: true
+	VsockID *string `json:"vsock_id"`
 }
 
 // Validate validates this vsock
@@ -47,7 +52,11 @@ func (m *Vsock) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateID(formats); err != nil {
+	if err := m.validateUdsPath(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateVsockID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -59,20 +68,29 @@ func (m *Vsock) Validate(formats strfmt.Registry) error {
 
 func (m *Vsock) validateGuestCid(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.GuestCid) { // not required
-		return nil
+	if err := validate.Required("guest_cid", "body", m.GuestCid); err != nil {
+		return err
 	}
 
-	if err := validate.MinimumInt("guest_cid", "body", int64(m.GuestCid), 3, false); err != nil {
+	if err := validate.MinimumInt("guest_cid", "body", int64(*m.GuestCid), 3, false); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (m *Vsock) validateID(formats strfmt.Registry) error {
+func (m *Vsock) validateUdsPath(formats strfmt.Registry) error {
 
-	if err := validate.Required("id", "body", m.ID); err != nil {
+	if err := validate.Required("uds_path", "body", m.UdsPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Vsock) validateVsockID(formats strfmt.Registry) error {
+
+	if err := validate.Required("vsock_id", "body", m.VsockID); err != nil {
 		return err
 	}
 

--- a/client/operations/operations_client.go
+++ b/client/operations/operations_client.go
@@ -400,7 +400,7 @@ PutGuestVsockByID creates new vsock with ID specified by the id parameter
 
 If the vsock device with the specified ID already exists, its body will be updated based on the new input. May fail if update is not possible.
 */
-func (a *Client) PutGuestVsockByID(params *PutGuestVsockByIDParams) (*PutGuestVsockByIDCreated, *PutGuestVsockByIDNoContent, error) {
+func (a *Client) PutGuestVsockByID(params *PutGuestVsockByIDParams) (*PutGuestVsockByIDNoContent, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutGuestVsockByIDParams()
@@ -419,15 +419,9 @@ func (a *Client) PutGuestVsockByID(params *PutGuestVsockByIDParams) (*PutGuestVs
 		Client:             params.HTTPClient,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	switch value := result.(type) {
-	case *PutGuestVsockByIDCreated:
-		return value, nil, nil
-	case *PutGuestVsockByIDNoContent:
-		return nil, value, nil
-	}
-	return nil, nil, nil
+	return result.(*PutGuestVsockByIDNoContent), nil
 
 }
 
@@ -509,7 +503,7 @@ type ClientIface interface {
 	PutGuestBootSource(params *PutGuestBootSourceParams) (*PutGuestBootSourceNoContent, error)
 	PutGuestDriveByID(params *PutGuestDriveByIDParams) (*PutGuestDriveByIDNoContent, error)
 	PutGuestNetworkInterfaceByID(params *PutGuestNetworkInterfaceByIDParams) (*PutGuestNetworkInterfaceByIDNoContent, error)
-	PutGuestVsockByID(params *PutGuestVsockByIDParams) (*PutGuestVsockByIDCreated, *PutGuestVsockByIDNoContent, error)
+	PutGuestVsockByID(params *PutGuestVsockByIDParams) (*PutGuestVsockByIDNoContent, error)
 	PutLogger(params *PutLoggerParams) (*PutLoggerNoContent, error)
 	PutMachineConfiguration(params *PutMachineConfigurationParams) (*PutMachineConfigurationNoContent, error)
 }

--- a/client/operations/put_guest_vsock_by_id_responses.go
+++ b/client/operations/put_guest_vsock_by_id_responses.go
@@ -37,12 +37,6 @@ type PutGuestVsockByIDReader struct {
 // ReadResponse reads a server response into the received o.
 func (o *PutGuestVsockByIDReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
-	case 201:
-		result := NewPutGuestVsockByIDCreated()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return result, nil
 	case 204:
 		result := NewPutGuestVsockByIDNoContent()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -67,27 +61,6 @@ func (o *PutGuestVsockByIDReader) ReadResponse(response runtime.ClientResponse, 
 	}
 }
 
-// NewPutGuestVsockByIDCreated creates a PutGuestVsockByIDCreated with default headers values
-func NewPutGuestVsockByIDCreated() *PutGuestVsockByIDCreated {
-	return &PutGuestVsockByIDCreated{}
-}
-
-/*PutGuestVsockByIDCreated handles this case with default header values.
-
-Vsock created
-*/
-type PutGuestVsockByIDCreated struct {
-}
-
-func (o *PutGuestVsockByIDCreated) Error() string {
-	return fmt.Sprintf("[PUT /vsocks/{id}][%d] putGuestVsockByIdCreated ", 201)
-}
-
-func (o *PutGuestVsockByIDCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	return nil
-}
-
 // NewPutGuestVsockByIDNoContent creates a PutGuestVsockByIDNoContent with default headers values
 func NewPutGuestVsockByIDNoContent() *PutGuestVsockByIDNoContent {
 	return &PutGuestVsockByIDNoContent{}
@@ -95,7 +68,7 @@ func NewPutGuestVsockByIDNoContent() *PutGuestVsockByIDNoContent {
 
 /*PutGuestVsockByIDNoContent handles this case with default header values.
 
-Vsock updated
+Vsock created/updated
 */
 type PutGuestVsockByIDNoContent struct {
 }

--- a/client/swagger.yaml
+++ b/client/swagger.yaml
@@ -2,9 +2,10 @@ swagger: "2.0"
 info:
   title: Firecracker API
   description: RESTful public-facing API.
-               The API is accessible through HTTP calls on specific URLs carrying JSON modeled data.
+               The API is accessible through HTTP calls on specific URLs
+               carrying JSON modeled data.
                The transport medium is a Unix Domain Socket.
-  version: 0.17.0
+  version: 0.18.0
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"
@@ -79,39 +80,6 @@ paths:
           description: Boot source created/updated
         400:
           description: Boot source cannot be created due to bad input
-          schema:
-            $ref: "#/definitions/Error"
-        default:
-          description: Internal server error
-          schema:
-            $ref: "#/definitions/Error"
-
-  /vsocks/{id}:
-    put:
-      summary: Creates new vsock with ID specified by the id parameter.
-      description:
-        If the vsock device with the specified ID already exists, its body will
-        be updated based on the new input. May fail if update is not possible.
-      operationId: putGuestVsockByID
-      parameters:
-      - name: id
-        in: path
-        description: The id of the vsock device
-        required: true
-        type: string
-      - name: body
-        in: body
-        description: Guest vsock properties
-        required: true
-        schema:
-          $ref: "#/definitions/Vsock"
-      responses:
-        201:
-          description: Vsock created
-        204:
-          description: Vsock updated
-        400:
-          description: Vsock cannot be created due to bad input
           schema:
             $ref: "#/definitions/Error"
         default:
@@ -385,6 +353,37 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  /vsocks/{id}:
+    put:
+      summary: Creates new vsock with ID specified by the id parameter.
+      description:
+        If the vsock device with the specified ID already exists, its body will
+        be updated based on the new input. May fail if update is not possible.
+      operationId: putGuestVsockByID
+      parameters:
+      - name: id
+        in: path
+        description: The id of the vsock device
+        required: true
+        type: string
+      - name: body
+        in: body
+        description: Guest vsock properties
+        required: true
+        schema:
+          $ref: "#/definitions/Vsock"
+      responses:
+        204:
+          description: Vsock created/updated
+        400:
+          description: Vsock cannot be created due to bad input
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: Internal server error
+          schema:
+            $ref: "#/definitions/Error"
+
 definitions:
   BootSource:
     type: object
@@ -644,14 +643,30 @@ definitions:
         format: int64
         description: The amount of milliseconds it takes for the bucket to refill.
         minimum: 0
+
   Vsock:
     type: object
+    description:
+      Defines a vsock device, backed by a set of Unix Domain Sockets, on the host side.
+      For host-initiated connections, Firecracker will be listening on the Unix socket
+      identified by the path `uds_path`. Firecracker will create this socket, bind and
+      listen on it. Host-initiated connections will be performed by connection to this
+      socket and issuing a connection forwarding request to the desired guest-side vsock
+      port (i.e. `CONNECT 52\n`, to connect to port 52).
+      For guest-initiated connections, Firecracker will expect host software to be
+      bound and listening on Unix sockets at `uds_path_<PORT>`.
+      E.g. "/path/to/host_vsock.sock_52" for port number 52.
     required:
-      - id
+      - vsock_id
+      - guest_cid
+      - uds_path
     properties:
-      id:
+      vsock_id:
         type: string
       guest_cid:
         type: integer
         minimum: 3
         description: Guest Vsock CID
+      uds_path:
+        type: string
+        description: Path to UNIX domain socket, used to proxy vsock connections.

--- a/fctesting/firecracker_mock_client.go
+++ b/fctesting/firecracker_mock_client.go
@@ -32,7 +32,7 @@ type MockClient struct {
 	PutGuestBootSourceFn             func(params *ops.PutGuestBootSourceParams) (*ops.PutGuestBootSourceNoContent, error)
 	PutGuestDriveByIDFn              func(params *ops.PutGuestDriveByIDParams) (*ops.PutGuestDriveByIDNoContent, error)
 	PutGuestNetworkInterfaceByIDFn   func(params *ops.PutGuestNetworkInterfaceByIDParams) (*ops.PutGuestNetworkInterfaceByIDNoContent, error)
-	PutGuestVsockByIDFn              func(params *ops.PutGuestVsockByIDParams) (*ops.PutGuestVsockByIDCreated, *ops.PutGuestVsockByIDNoContent, error)
+	PutGuestVsockByIDFn              func(params *ops.PutGuestVsockByIDParams) (*ops.PutGuestVsockByIDNoContent, error)
 	PutLoggerFn                      func(params *ops.PutLoggerParams) (*ops.PutLoggerNoContent, error)
 	PutMachineConfigurationFn        func(params *ops.PutMachineConfigurationParams) (*ops.PutMachineConfigurationNoContent, error)
 }
@@ -133,12 +133,12 @@ func (c *MockClient) PutGuestNetworkInterfaceByID(params *ops.PutGuestNetworkInt
 	return nil, nil
 }
 
-func (c *MockClient) PutGuestVsockByID(params *ops.PutGuestVsockByIDParams) (*ops.PutGuestVsockByIDCreated, *ops.PutGuestVsockByIDNoContent, error) {
+func (c *MockClient) PutGuestVsockByID(params *ops.PutGuestVsockByIDParams) (*ops.PutGuestVsockByIDNoContent, error) {
 	if c.PutGuestVsockByIDFn != nil {
 		return c.PutGuestVsockByIDFn(params)
 	}
 
-	return nil, nil, nil
+	return nil, nil
 }
 
 func (c *MockClient) PutLogger(params *ops.PutLoggerParams) (*ops.PutLoggerNoContent, error) {

--- a/firecracker.go
+++ b/firecracker.go
@@ -183,16 +183,16 @@ func (f *Client) PutGuestDriveByID(ctx context.Context, driveID string, drive *m
 	return f.client.Operations.PutGuestDriveByID(params)
 }
 
-// PutGuestVsockByIDOpt is a functional option to be used for the
+// PutGuestVsockOpt is a functional option to be used for the
 // PutGuestVsockByID API in setting any additional optional fields.
 type PutGuestVsockByIDOpt func(*ops.PutGuestVsockByIDParams)
 
-// PutGuestVsockByID is a wrapper for the swagger generated client to make
+// PutGuestVsock is a wrapper for the swagger generated client to make
 // calling of the API easier.
-func (f *Client) PutGuestVsockByID(ctx context.Context, vsockID string, vsock *models.Vsock, opts ...PutGuestVsockByIDOpt) (*ops.PutGuestVsockByIDCreated, *ops.PutGuestVsockByIDNoContent, error) {
+func (f *Client) PutGuestVsockByID(ctx context.Context, vsock *models.Vsock, opts ...PutGuestVsockByIDOpt) (*ops.PutGuestVsockByIDNoContent, error) {
 	params := ops.NewPutGuestVsockByIDParams()
 	params.SetContext(ctx)
-	params.SetID(vsockID)
+	params.SetID(*vsock.VsockID)
 	params.SetBody(vsock)
 	for _, opt := range opts {
 		opt(params)

--- a/firecracker.go
+++ b/firecracker.go
@@ -183,16 +183,16 @@ func (f *Client) PutGuestDriveByID(ctx context.Context, driveID string, drive *m
 	return f.client.Operations.PutGuestDriveByID(params)
 }
 
-// PutGuestVsockOpt is a functional option to be used for the
+// PutGuestVsockByIDOpt is a functional option to be used for the
 // PutGuestVsockByID API in setting any additional optional fields.
 type PutGuestVsockByIDOpt func(*ops.PutGuestVsockByIDParams)
 
-// PutGuestVsock is a wrapper for the swagger generated client to make
+// PutGuestVsockByID is a wrapper for the swagger generated client to make
 // calling of the API easier.
 func (f *Client) PutGuestVsockByID(ctx context.Context, vsock *models.Vsock, opts ...PutGuestVsockByIDOpt) (*ops.PutGuestVsockByIDNoContent, error) {
 	params := ops.NewPutGuestVsockByIDParams()
 	params.SetContext(ctx)
-	params.SetID(*vsock.VsockID)
+	params.ID = *vsock.VsockID
 	params.SetBody(vsock)
 	for _, opt := range opts {
 		opt(params)

--- a/firecracker.go
+++ b/firecracker.go
@@ -192,7 +192,7 @@ type PutGuestVsockByIDOpt func(*ops.PutGuestVsockByIDParams)
 func (f *Client) PutGuestVsockByID(ctx context.Context, vsock *models.Vsock, opts ...PutGuestVsockByIDOpt) (*ops.PutGuestVsockByIDNoContent, error) {
 	params := ops.NewPutGuestVsockByIDParams()
 	params.SetContext(ctx)
-	params.ID = *vsock.VsockID
+	params.SetID(StringValue(vsock.VsockID))
 	params.SetBody(vsock)
 	for _, opt := range opts {
 		opt(params)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -592,9 +592,9 @@ func TestHandlers(t *testing.T) {
 		{
 			Handler: AddVsocksHandler,
 			Client: fctesting.MockClient{
-				PutGuestVsockByIDFn: func(params *ops.PutGuestVsockByIDParams) (*ops.PutGuestVsockByIDCreated, *ops.PutGuestVsockByIDNoContent, error) {
+				PutGuestVsockByIDFn: func(params *ops.PutGuestVsockByIDParams) (*ops.PutGuestVsockByIDNoContent, error) {
 					called = AddVsocksHandler.Name
-					return &ops.PutGuestVsockByIDCreated{}, &ops.PutGuestVsockByIDNoContent{}, nil
+					return &ops.PutGuestVsockByIDNoContent{}, nil
 				},
 			},
 			Config: Config{

--- a/machine.go
+++ b/machine.go
@@ -222,6 +222,8 @@ type RateLimiterSet struct {
 // VsockDevice represents a vsock connection between the host and the guest
 // microVM.
 type VsockDevice struct {
+	// ID defines the vsock's device ID for firecracker.
+	ID string
 	// Path defines the filesystem path of the vsock device on the host.
 	Path string
 	// CID defines the 32-bit Context Identifier for the vsock device.  See
@@ -398,8 +400,8 @@ func (m *Machine) createNetworkInterfaces(ctx context.Context, ifaces ...Network
 }
 
 func (m *Machine) addVsocks(ctx context.Context, vsocks ...VsockDevice) error {
-	for i, dev := range m.Cfg.VsockDevices {
-		if err := m.addVsock(ctx, fmt.Sprintf("%d", i), dev); err != nil {
+	for _, dev := range m.Cfg.VsockDevices {
+		if err := m.addVsock(ctx, dev); err != nil {
 			return err
 		}
 	}
@@ -729,11 +731,11 @@ func (m *Machine) attachDrive(ctx context.Context, dev models.Drive) error {
 }
 
 // addVsock adds a vsock to the instance
-func (m *Machine) addVsock(ctx context.Context, id string, dev VsockDevice) error {
+func (m *Machine) addVsock(ctx context.Context, dev VsockDevice) error {
 	vsockCfg := models.Vsock{
 		GuestCid: Int64(int64(dev.CID)),
 		UdsPath:  &dev.Path,
-		VsockID:  &id,
+		VsockID:  &dev.ID,
 	}
 
 	resp, err := m.client.PutGuestVsockByID(ctx, &vsockCfg)

--- a/machine.go
+++ b/machine.go
@@ -398,8 +398,8 @@ func (m *Machine) createNetworkInterfaces(ctx context.Context, ifaces ...Network
 }
 
 func (m *Machine) addVsocks(ctx context.Context, vsocks ...VsockDevice) error {
-	for _, dev := range m.Cfg.VsockDevices {
-		if err := m.addVsock(ctx, dev); err != nil {
+	for i, dev := range m.Cfg.VsockDevices {
+		if err := m.addVsock(ctx, fmt.Sprintf("%d", i), dev); err != nil {
 			return err
 		}
 	}
@@ -729,13 +729,14 @@ func (m *Machine) attachDrive(ctx context.Context, dev models.Drive) error {
 }
 
 // addVsock adds a vsock to the instance
-func (m *Machine) addVsock(ctx context.Context, dev VsockDevice) error {
+func (m *Machine) addVsock(ctx context.Context, id string, dev VsockDevice) error {
 	vsockCfg := models.Vsock{
-		GuestCid: int64(dev.CID),
-		ID:       &dev.Path,
+		GuestCid: Int64(int64(dev.CID)),
+		UdsPath:  &dev.Path,
+		VsockID:  &id,
 	}
 
-	resp, _, err := m.client.PutGuestVsockByID(ctx, dev.Path, &vsockCfg)
+	resp, err := m.client.PutGuestVsockByID(ctx, &vsockCfg)
 	if err != nil {
 		return err
 	}

--- a/machine_test.go
+++ b/machine_test.go
@@ -562,6 +562,7 @@ func testAttachSecondaryDrive(ctx context.Context, t *testing.T, m *Machine) {
 
 func testAttachVsock(ctx context.Context, t *testing.T, m *Machine) {
 	dev := VsockDevice{
+		ID:   "1",
 		CID:  3,
 		Path: "foo",
 	}

--- a/machine_test.go
+++ b/machine_test.go
@@ -561,10 +561,11 @@ func testAttachSecondaryDrive(ctx context.Context, t *testing.T, m *Machine) {
 }
 
 func testAttachVsock(ctx context.Context, t *testing.T, m *Machine) {
+	timestamp := strconv.Itoa(int(time.Now().UnixNano()))
 	dev := VsockDevice{
 		ID:   "1",
 		CID:  3,
-		Path: "foo",
+		Path: timestamp + ".vsock",
 	}
 	err := m.addVsock(ctx, dev)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*
#121 

*Description of changes:*
- Updates swagger.yml and regenerates client and client operations.
- Manual changes to swagger.yml to reflect reality of 0.18 (just `id => vsock_id`)
- Adapt non-generated code to use the new APIs
- Sets the vsock device index as its ID (instead of a name based on the path)
- Is not backwards compatible with 0.17 (at least, I don't think so)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
