### PR TITLE
network: set broad permissions

### DIFF
--- a/network_test.go
+++ b/network_test.go
@@ -252,12 +252,12 @@ func TestNetworkMachineCNI(t *testing.T) {
 
 	cniCacheDir := filepath.Join(testCNIDir, "cni.cache")
 	require.NoError(t,
-		os.MkdirAll(cniCacheDir, 0755),
+		os.MkdirAll(cniCacheDir, 0777), // broad permissions for tests
 		"failed to create cni cache dir")
 
 	cniConfDir := filepath.Join(testCNIDir, "cni.conf")
 	require.NoError(t,
-		os.MkdirAll(cniConfDir, 0755),
+		os.MkdirAll(cniConfDir, 0777), // broad permissions for tests
 		"failed to create cni conf dir")
 
 	const ifName = "veth0"
@@ -283,7 +283,7 @@ func TestNetworkMachineCNI(t *testing.T) {
 
 	cniConfPath := filepath.Join(cniConfDir, fmt.Sprintf("%s.conflist", networkName))
 	require.NoError(t,
-		ioutil.WriteFile(cniConfPath, []byte(cniConf), 0644),
+		ioutil.WriteFile(cniConfPath, []byte(cniConf), 0666), // broad permissions for tests
 		"failed to write cni conf file")
 
 	numVMs := 10


### PR DESCRIPTION
Some of the tests in this package are expected to run as root in order
to perform privileged operations.  These tests may also create files,
but if they do so without setting the w bit for the other group, the
files will not be deletable after the test by a normal user.  This
commit sets the writable bit on the file permissions only so that the
files can be deleted by non-root users after the tests complete.

*Issue #, if available:*
https://github.com/firecracker-microvm/firecracker-go-sdk/pull/134

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
