### PR TITLE
handlers: moved fifo setup/cleanup to handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ firecracker
 jailer
 firecracker-*
 vmlinux
+root-drive.img
+TestPID.img

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,16 +1,19 @@
 package firecracker
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
 	ops "github.com/firecracker-microvm/firecracker-go-sdk/client/operations"
 	"github.com/firecracker-microvm/firecracker-go-sdk/fctesting"
+	"github.com/pkg/errors"
 )
 
 func TestHandlerListAppend(t *testing.T) {
@@ -660,6 +663,76 @@ func TestHandlers(t *testing.T) {
 	}
 }
 
+func TestCreateLogFilesHandler(t *testing.T) {
+	logWriterBuf := &bytes.Buffer{}
+	config := Config{
+		LogFifo:       filepath.Join(testDataPath, "firecracker-log.fifo"),
+		MetricsFifo:   filepath.Join(testDataPath, "firecracker-metrics.fifo"),
+		FifoLogWriter: logWriterBuf,
+	}
+
+	defer func() {
+		os.Remove(config.LogFifo)
+		os.Remove(config.MetricsFifo)
+	}()
+
+	ctx := context.Background()
+	m, err := NewMachine(ctx, config, WithLogger(fctesting.NewLogEntry(t)))
+	if err != nil {
+		t.Fatalf("failed to create machine: %v", err)
+	}
+
+	// spin off goroutine to write to Log fifo so we don't block
+	doneChan := make(chan struct{}, 1)
+	go func() {
+		defer close(doneChan)
+
+		// try to open file
+		fifoPipe, err := openFileRetry(config.LogFifo)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if _, err := fifoPipe.WriteString("data\n"); err != nil {
+			t.Errorf("Failed to write to fifo %v", err)
+		}
+
+		fifoPipe.Close()
+		return
+	}()
+
+	// Execute Handler
+	if err := CreateLogFilesHandler.Fn(ctx, m); err != nil {
+		t.Errorf("failed to call CreateLogFilesHandler function: %v", err)
+		return
+	}
+
+	// Block until writing go routine is done to check data that was written
+	<-doneChan
+
+	// Poll for verifying logs were written as we need to allow time
+	// for copying from the log fifo into the FifoLogWriter
+	timer := time.NewTimer(1 * time.Second)
+	for {
+		select {
+		case <-timer.C:
+			t.Fatal("timed out reading from log writer")
+		default:
+			logData, err := logWriterBuf.ReadString('\n')
+			if err != nil {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+
+			if logData != "data\n" {
+				t.Errorf("expected 'data' written to log got '%s'", logData)
+			}
+			return
+		}
+	}
+
+}
+
 func compareHandlerLists(l1, l2 HandlerList) bool {
 	if l1.Len() != l2.Len() {
 		return false
@@ -680,4 +753,22 @@ func compareHandlerLists(l1, l2 HandlerList) bool {
 	}
 
 	return true
+}
+
+func openFileRetry(filePath string) (file *os.File, err error) {
+	timer := time.NewTimer(1 * time.Second)
+	for {
+		select {
+		case <-timer.C:
+			err = errors.New("timed out waiting for file")
+			return
+		default:
+			file, err = os.OpenFile(filePath, os.O_WRONLY, os.ModePerm)
+			if err == nil {
+				timer.Stop()
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
 }

--- a/machine.go
+++ b/machine.go
@@ -455,18 +455,6 @@ func (m *Machine) startVMM(ctx context.Context) error {
 			}
 			return nil
 		},
-		func() error {
-			if err := os.Remove(m.Cfg.LogFifo); !os.IsNotExist(err) {
-				return err
-			}
-			return nil
-		},
-		func() error {
-			if err := os.Remove(m.Cfg.MetricsFifo); !os.IsNotExist(err) {
-				return err
-			}
-			return nil
-		},
 	)
 
 	errCh := make(chan error)
@@ -584,12 +572,6 @@ func (m *Machine) setupLogging(ctx context.Context) error {
 		m.Cfg.LogFifo,
 		m.Cfg.MetricsFifo,
 	)
-
-	if m.Cfg.FifoLogWriter != nil {
-		if err := captureFifoToFile(m.logger, m.Cfg.LogFifo, m.Cfg.FifoLogWriter); err != nil {
-			return err
-		}
-	}
 
 	return nil
 }


### PR DESCRIPTION
Carries https://github.com/firecracker-microvm/firecracker-go-sdk/pull/134

fifos for Firecracker logs and metrics are now created and queued for cleanup in CreateLogFilesHandler.  This removes warnings when using the jailer and setting other paths for the fifos.

Fixes: https://github.com/firecracker-microvm/firecracker-go-sdk/issues/133
Original contribution: https://github.com/firecracker-microvm/firecracker-go-sdk/pull/134

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.