### PR TITLE
Fixes issue where FifoLogWriter would hang

### DIFF
--- a/fctesting/test_writer.go
+++ b/fctesting/test_writer.go
@@ -1,0 +1,12 @@
+package fctesting
+
+// TestWriter is used to mock out writing and/or do other things such as
+// syncing when to do assertions in the event that a writer is used in a
+// goroutine
+type TestWriter struct {
+	WriteFn func([]byte) (int, error)
+}
+
+func (w *TestWriter) Write(b []byte) (int, error) {
+	return w.WriteFn(b)
+}


### PR DESCRIPTION
Prior to this fix the FifoLogWriter would hang the process due to
waiting for the fifo to be connected to firecracker when attempting to
open the fifo. This fix wraps the capture fifo method in a goroutine.

Signed-off-by: xibz <impactbchang@gmail.com>

Fixes #143 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
