### PR TITLE
Fixes leak of open file during capture fifo

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -152,7 +152,7 @@ var CreateLogFilesHandler = Handler{
 		)
 
 		if m.Cfg.FifoLogWriter != nil {
-			if err := captureFifoToFile(m.logger, logFifoPath, m.Cfg.FifoLogWriter); err != nil {
+			if err := m.captureFifoToFile(m.logger, logFifoPath, m.Cfg.FifoLogWriter); err != nil {
 				m.logger.Warnf("captureFifoToFile() returned %s. Continuing anyway.", err)
 			}
 		}


### PR DESCRIPTION
This change fixes a leak that occurs when using context cancel or
stopping the VM. The goroutine in `captureFifoToFile` spins up a
goroutine to copy the contents of the file, but will continue reading
from the file even if the VM shuts down. To prevent this, we now look at
the context to see if it has finished or if the machine has closed its
exit channel

Signed-off-by: xibz <impactbchang@gmail.com>

Fixes #146 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
