### PR TITLE
Moves NetNS to Config from JailerConfig 

### DIFF
--- a/jailer.go
+++ b/jailer.go
@@ -86,10 +86,6 @@ type JailerConfig struct {
 	// default is /srv/jailer
 	ChrootBaseDir string
 
-	// NetNS represents the path to a network namespace handle. If present, the
-	// jailer will use this to join the associated network namespace
-	NetNS string
-
 	//  Daemonize is set to true, call setsid() and redirect STDIN, STDOUT, and
 	//  STDERR to /dev/null
 	Daemonize bool
@@ -112,13 +108,6 @@ type JailerConfig struct {
 	Stderr io.Writer
 	// Stdin specifies the IO reader for STDIN to use when spawning the jailer.
 	Stdin io.Reader
-}
-
-func (jailerCfg *JailerConfig) netNSPath() string {
-	if jailerCfg == nil {
-		return ""
-	}
-	return jailerCfg.NetNS
 }
 
 // JailerCommandBuilder will build a jailer command. This can be used to
@@ -348,8 +337,8 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
 		builder = builder.WithBin(jailerBinary)
 	}
 
-	if netNS := cfg.JailerCfg.NetNS; netNS != "" {
-		builder = builder.WithNetNS(netNS)
+	if cfg.NetNS != "" {
+		builder = builder.WithNetNS(cfg.NetNS)
 	}
 
 	if stdin := cfg.JailerCfg.Stdin; stdin != nil {

--- a/jailer_test.go
+++ b/jailer_test.go
@@ -11,6 +11,7 @@ var testCases = []struct {
 	name             string
 	jailerCfg        JailerConfig
 	expectedArgs     []string
+	netns            string
 	expectedSockPath string
 }{
 	{
@@ -69,7 +70,8 @@ var testCases = []struct {
 		expectedSockPath: filepath.Join(defaultJailerPath, "my-test-id", rootfsFolderName, "api.socket"),
 	},
 	{
-		name: "optional fields",
+		name:  "optional fields",
+		netns: "/path/to/netns",
 		jailerCfg: JailerConfig{
 			ID:             "my-test-id",
 			UID:            Int(123),
@@ -77,7 +79,6 @@ var testCases = []struct {
 			NumaNode:       Int(1),
 			ChrootStrategy: NewNaiveChrootStrategy("path", "kernel-image-path"),
 			ExecFile:       "/path/to/firecracker",
-			NetNS:          "/net/namespace",
 			ChrootBaseDir:  "/tmp",
 			SeccompLevel:   SeccompLevelAdvanced,
 			JailerBinary:   "/path/to/the/jailer",
@@ -97,7 +98,7 @@ var testCases = []struct {
 			"--chroot-base-dir",
 			"/tmp",
 			"--netns",
-			"/net/namespace",
+			"/path/to/netns",
 			"--seccomp-level",
 			"2",
 		},
@@ -124,8 +125,8 @@ func TestJailerBuilder(t *testing.T) {
 				b = b.WithChrootBaseDir(c.jailerCfg.ChrootBaseDir)
 			}
 
-			if len(c.jailerCfg.NetNS) > 0 {
-				b = b.WithNetNS(c.jailerCfg.NetNS)
+			if c.netns != "" {
+				b = b.WithNetNS(c.netns)
 			}
 
 			if c.jailerCfg.Daemonize {
@@ -150,6 +151,7 @@ func TestJail(t *testing.T) {
 			}
 			cfg := &Config{
 				JailerCfg: &c.jailerCfg,
+				NetNS:     c.netns,
 			}
 			jail(context.Background(), m, cfg)
 


### PR DESCRIPTION
This change moves the NetNS field from the JailerConfig to the Config.
This makes the most sense since net namespaces are not subject to only
jailers, but can be used generally as well.

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
