### PR TITLE
Enable Go's race detector

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,7 +52,7 @@ steps:
       - 'ln -s /var/lib/fc-ci/rootfs.ext4 testdata/root-drive.img'
       - 'ln -s /usr/local/bin/firecracker-v0.19.0 testdata/firecracker'
       - 'ln -s /usr/local/bin/jailer-v0.19.0 testdata/jailer'
-      - "FC_TEST_TAP=fc-test-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1' DISABLE_ROOT_TESTS=true"
+      - "FC_TEST_TAP=fc-test-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS=true"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
 
@@ -63,7 +63,7 @@ steps:
       - 'cp /usr/local/bin/firecracker-v0.19.0 testdata/firecracker'
       - 'cp /usr/local/bin/jailer-v0.19.0 testdata/jailer'
       - 'make -C cni install CNI_BIN_ROOT=$(pwd)/testdata/bin'
-      - "sudo FC_TEST_TAP=fc-root-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1' DISABLE_ROOT_TESTS="
+      - "sudo FC_TEST_TAP=fc-root-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS="
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
 


### PR DESCRIPTION
*Issue #, if available:*

#157

*Description of changes:*

Seems Go's race detector can detect the leak issue (while I haven't tested @xibz's fix yet) and no false positives. Can we enable the detector on BuildKite?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
