### PR TITLE
Include the firewall CNI plugin in sample configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ With the following file at `/etc/cni/conf.d/fcnet.conflist`:
       }
     },
     {
+      "type": "firewall"
+    },
+    {
       "type": "tc-redirect-tap"
     }
   ]
@@ -79,7 +82,8 @@ With the following file at `/etc/cni/conf.d/fcnet.conflist`:
 
 and the 
 [`ptp`](https://github.com/containernetworking/plugins/tree/master/plugins/main/ptp), 
-[`host-local`](https://github.com/containernetworking/plugins/tree/master/plugins/ipam/host-local) 
+[`host-local`](https://github.com/containernetworking/plugins/tree/master/plugins/ipam/host-local),
+[`firewall`](https://github.com/containernetworking/plugins/tree/master/plugins/meta/firewall),
 and [`tc-redirect-tap`](cni/Makefile)
 CNI plugin binaries installed under `/opt/cni/bin`, you can specify, in the Go SDK API, 
 a `Machine` with the following `NetworkInterface`:


### PR DESCRIPTION
The "ptp" plugin's "ipMasq: true" setting is, in practice, very inconsistent in
actually setting up networking from the veth device to host networks. The
firewall plugin has been much more consistent, so including it as the example
configuration results in a better default experience for users trying out CNI
support.

Signed-off-by: Erik Sipsma <sipsma@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
