### PR TITLE
Bump version to 0.19.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -14,4 +14,4 @@
 package firecracker
 
 // Version represents the current version of the SDK.
-const Version = "0.17.0"
+const Version = "0.19.0"


### PR DESCRIPTION
This releases v0.19.0, which includes support for network configuration via CNI and firecracker's new vsock implementation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
