### PR TITLE
Fixes typo for args.TCRedirectTapGID

### DIFF
--- a/cni/cmd/tc-redirect-tap/args/args.go
+++ b/cni/cmd/tc-redirect-tap/args/args.go
@@ -2,4 +2,4 @@ package args
 
 const TCRedirectTapName = "TC_REDIRECT_TAP_NAME"
 const TCRedirectTapUID = "TC_REDIRECT_TAP_UID"
-const TCRedirectTapGUID = "TC_REDIRECT_TAP_GID"
+const TCRedirectTapGID = "TC_REDIRECT_TAP_GID"

--- a/cni/cmd/tc-redirect-tap/main.go
+++ b/cni/cmd/tc-redirect-tap/main.go
@@ -152,7 +152,7 @@ func newPlugin(args *skel.CmdArgs) (*plugin, error) {
 		plugin.tapUID = tapUID
 	}
 
-	if tapGIDVal, wasDefined := parsedArgs[pluginargs.TCRedirectTapGUID]; wasDefined {
+	if tapGIDVal, wasDefined := parsedArgs[pluginargs.TCRedirectTapGID]; wasDefined {
 		tapGID, err := strconv.Atoi(tapGIDVal)
 		if err != nil {
 			return nil, errors.Wrapf(err, "tapGID should be numeric convertible, got %q", tapGIDVal)


### PR DESCRIPTION
s/TCRedirectTapGUID/TCRedirectTapGID/g

Signed-off-by: xibz <impactbchang@gmail.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
