### PR TITLE
Release 0.20.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -69,8 +69,8 @@ steps:
     commands:
       - 'ln -s /var/lib/fc-ci/vmlinux.bin testdata/vmlinux'
       - 'ln -s /var/lib/fc-ci/rootfs.ext4 testdata/root-drive.img'
-      - 'ln -s /usr/local/bin/firecracker-v0.19.0 testdata/firecracker'
-      - 'ln -s /usr/local/bin/jailer-v0.19.0 testdata/jailer'
+      - 'ln -s /usr/local/bin/firecracker-v0.20.0 testdata/firecracker'
+      - 'ln -s /usr/local/bin/jailer-v0.20.0 testdata/jailer'
       - "FC_TEST_TAP=fc-test-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS=true"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
@@ -82,8 +82,8 @@ steps:
     commands:
       - 'ln -s /var/lib/fc-ci/vmlinux.bin testdata/vmlinux'
       - 'ln -s /var/lib/fc-ci/rootfs.ext4 testdata/root-drive.img'
-      - 'cp /usr/local/bin/firecracker-v0.19.0 testdata/firecracker'
-      - 'cp /usr/local/bin/jailer-v0.19.0 testdata/jailer'
+      - 'cp /usr/local/bin/firecracker-v0.20.0 testdata/firecracker'
+      - 'cp /usr/local/bin/jailer-v0.20.0 testdata/jailer'
       - 'make -C cni install CNI_BIN_ROOT=$(pwd)/testdata/bin'
       - "sudo FC_TEST_TAP=fc-root-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS="
     agents:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.20.0
+* Moves the NetNS field to `Config` from `JailerConfig` (#155).
+* Supports forcing CNI network creation (#130).
+* Adds `FIRECRACKER_GO_SDK_INIT_TIMEOUT_SECONDS` and `FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS` environment variables to configure timeouts (#165).
+* Adds `ForwardSignals` to explicitly configure signal handling (#166).
+
 # 0.19.0
 * Firecracker v0.19 API: Vsock API call: PUT /vsocks/{id} changed to PUT /vsock and no longer
   appear to support multiple vsock devices. Any subsequent calls to this API

--- a/HACKING.md
+++ b/HACKING.md
@@ -12,7 +12,7 @@ environment variable.
 
 You need some external resources in order to run the tests, as described below:
 
-1. A firecracker and jailer binary (tested with 0.12.0) must either be
+1. A firecracker and jailer binary (tested with 0.20.0) must either be
    installed as `./testdata/firecracker` or the path must be specified through
    the `FC_TEST_BIN` environment variable. The jailer requires go test to be
    run with sudo and can also be turned off by setting the `DISABLE_ROOT_TESTS`
@@ -61,7 +61,6 @@ Amazon EC2 Bare Metal Instances.
 The instance is pre-configured to have
 
   - firecracker and jailer under /usr/local/bin.
-    Both of them are currently v0.17.0 and built with
-    `cargo build --features vsock --release` to enable vsock support
+    Both of them are currently v0.20.0.
   - vmlinux.bin from
     https://s3.amazonaws.com/spec.ccfc.min/img/hello/kernel/hello-vmlinux.bin

--- a/version.go
+++ b/version.go
@@ -14,4 +14,4 @@
 package firecracker
 
 // Version represents the current version of the SDK.
-const Version = "0.19.0"
+const Version = "0.20.0"


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

Seems Firecracker 0.20.0 doesn't have any API changes, but we have a few fixes on our client code and keeping the versions in-sync may help customers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
