### PR TITLE
Added env's to be able to configure timouts

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -33,6 +33,14 @@ You need some external resources in order to run the tests, as described below:
 With all of those set up, `make test EXTRAGOARGS=-v` should create a Firecracker
 process and run the Linux kernel in a MicroVM.
 
+There is also a possibility to configure timeouts in firecracker-go-sdk,
+you can set those env's to customize tests flow:
+```
+    FIRECRACKER_GO_SDK_INIT_TIMEOUT_SECONDS
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS
+```
+You can set them directly or with a help of buildkite, otherwise default values will be used.
+
 Regenerating the API client
 ---
 

--- a/machine.go
+++ b/machine.go
@@ -42,6 +42,11 @@ const (
 
 	// as specified in http://man7.org/linux/man-pages/man8/ip-netns.8.html
 	defaultNetNSDir = "/var/run/netns"
+
+	// env name to make firecracker init timeout configurable
+	firecrackerInitTimeoutEnv = "FIRECRACKER_GO_SDK_INIT_TIMEOUT_SECONDS"
+
+	defaultFirecrackerInitTimeoutSeconds = 3
 )
 
 // ErrAlreadyStarted signifies that the Machine has already started and cannot
@@ -492,7 +497,7 @@ func (m *Machine) startVMM(ctx context.Context) error {
 	}()
 
 	// Wait for firecracker to initialize:
-	err = m.waitForSocket(3*time.Second, errCh)
+	err = m.waitForSocket(time.Duration(m.client.firecrackerInitTimeout)*time.Second, errCh)
 	if err != nil {
 		err = errors.Wrapf(err, "Firecracker did not create API socket %s", m.Cfg.SocketPath)
 		m.fatalErr = err

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,8 @@ package firecracker
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"time"
 )
 
@@ -26,4 +28,14 @@ func waitForAliveVMM(ctx context.Context, client *Client) error {
 			}
 		}
 	}
+}
+
+// envValueOrDefaultInt check if env value exists and returns it or returns default value
+// provided as a second param to this function
+func envValueOrDefaultInt(envName string, def int) int {
+	envVal, err := strconv.Atoi(os.Getenv(envName))
+	if envVal == 0 || err != nil {
+		envVal = def
+	}
+	return envVal
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,12 @@
+package firecracker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvValueOrDefaultInt(t *testing.T) {
+	defaultVal := 500
+	assert.Equal(t, defaultVal, envValueOrDefaultInt("UNEXISTS_ENV", defaultVal))
+}


### PR DESCRIPTION
Signed-off-by: Boris Popovschi <zyqsempai@mail.ru>

Issue #164 

*Description of changes:*
Added `FIRECRACKER_INIT_TIMEOUT_SECONDS` env to configure init timeouts and `FIRECRACKER_REQUEST_TIMEOUT_MILLISECONDS` for request timeouts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
