### PR TITLE
Configurable signal handling, fix signal cleanup

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -894,7 +894,7 @@ func (m *Machine) setupSignals() {
 	}
 
 	m.logger.Debugf("Setting up signal handler: %v", signals)
-	sigchan := make(chan os.Signal)
+	sigchan := make(chan os.Signal, len(signals))
 	signal.Notify(sigchan, signals...)
 
 	go func() {

--- a/machine.go
+++ b/machine.go
@@ -898,11 +898,14 @@ func (m *Machine) setupSignals() {
 	signal.Notify(sigchan, signals...)
 
 	go func() {
-		select {
-		case sig := <-sigchan:
-			m.logger.Printf("Caught signal %s", sig)
-			m.cmd.Process.Signal(sig)
-		case <-m.exitCh:
+		for {
+			select {
+			case sig := <-sigchan:
+				m.logger.Printf("Caught signal %s", sig)
+				m.cmd.Process.Signal(sig)
+			case <-m.exitCh:
+				break
+			}
 		}
 
 		signal.Stop(sigchan)

--- a/machine.go
+++ b/machine.go
@@ -117,6 +117,10 @@ type Config struct {
 	// NetNS represents the path to a network namespace handle. If present, the
 	// application will use this to join the associated network namespace
 	NetNS string
+
+	// ForwardSignals is an optional list of signals to catch and forward to
+	// firecracker. If not provided, the default signals will be used.
+	ForwardSignals []os.Signal
 }
 
 // Validate will ensure that the required fields are set and that
@@ -481,20 +485,7 @@ func (m *Machine) startVMM(ctx context.Context) error {
 		close(errCh)
 	}()
 
-	// Set up a signal handler and pass INT, QUIT, and TERM through to firecracker
-	sigchan := make(chan os.Signal)
-	signal.Notify(sigchan, os.Interrupt,
-		syscall.SIGQUIT,
-		syscall.SIGTERM,
-		syscall.SIGHUP,
-		syscall.SIGABRT)
-	m.logger.Debugf("Setting up signal handler")
-	go func() {
-		if sig, ok := <-sigchan; ok {
-			m.logger.Printf("Caught signal %s", sig)
-			m.cmd.Process.Signal(sig)
-		}
-	}()
+	m.setupSignals()
 
 	// Wait for firecracker to initialize:
 	err = m.waitForSocket(time.Duration(m.client.firecrackerInitTimeout)*time.Second, errCh)
@@ -513,8 +504,6 @@ func (m *Machine) startVMM(ctx context.Context) error {
 			m.fatalErr = err
 		}
 
-		signal.Stop(sigchan)
-		close(sigchan)
 		close(m.exitCh)
 	}()
 
@@ -884,4 +873,39 @@ func (m *Machine) waitForSocket(timeout time.Duration, exitchan chan error) erro
 			return nil
 		}
 	}
+}
+
+// Set up a signal handler to pass through to firecracker
+func (m *Machine) setupSignals() {
+	signals := m.Cfg.ForwardSignals
+
+	if signals == nil {
+		signals = []os.Signal{
+			os.Interrupt,
+			syscall.SIGQUIT,
+			syscall.SIGTERM,
+			syscall.SIGHUP,
+			syscall.SIGABRT,
+		}
+	}
+
+	if len(signals) == 0 {
+		return
+	}
+
+	m.logger.Debugf("Setting up signal handler: %v", signals)
+	sigchan := make(chan os.Signal)
+	signal.Notify(sigchan, signals...)
+
+	go func() {
+		select {
+		case sig := <-sigchan:
+			m.logger.Printf("Caught signal %s", sig)
+			m.cmd.Process.Signal(sig)
+		case <-m.exitCh:
+		}
+
+		signal.Stop(sigchan)
+		close(sigchan)
+	}()
 }

--- a/machine.go
+++ b/machine.go
@@ -307,6 +307,16 @@ func NewMachine(ctx context.Context, cfg Config, opts ...Opt) (*Machine, error) 
 		cfg.VMID = randomID.String()
 	}
 
+	if cfg.ForwardSignals == nil {
+		cfg.ForwardSignals = []os.Signal{
+			os.Interrupt,
+			syscall.SIGQUIT,
+			syscall.SIGTERM,
+			syscall.SIGHUP,
+			syscall.SIGABRT,
+		}
+	}
+
 	m.machineConfig = cfg.MachineCfg
 	m.Cfg = cfg
 
@@ -878,16 +888,6 @@ func (m *Machine) waitForSocket(timeout time.Duration, exitchan chan error) erro
 // Set up a signal handler to pass through to firecracker
 func (m *Machine) setupSignals() {
 	signals := m.Cfg.ForwardSignals
-
-	if signals == nil {
-		signals = []os.Signal{
-			os.Interrupt,
-			syscall.SIGQUIT,
-			syscall.SIGTERM,
-			syscall.SIGHUP,
-			syscall.SIGABRT,
-		}
-	}
 
 	if len(signals) == 0 {
 		return

--- a/testdata/sigprint.sh
+++ b/testdata/sigprint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+typeset -i sig=1
+while (( sig < 65 )); do
+    trap "echo '$sig'" $sig 2>/dev/null 
+    let sig=sig+1
+done
+
+>&2 echo "Send signals to PID $$ and type [q] when done."
+
+while :
+do 
+  read -n1 input
+  [ "$input" == "q" ] && break
+  sleep .1
+done


### PR DESCRIPTION
*Issue #, if available:* #85 

*Description of changes:*
Adds a `DisableSignals` option to `machine.Config` for host apps that need to manage firecracker signals themselves. This also fixes an issue where signals weren't cleaned if the firecracker socket failed to open.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
