### PR TITLE
Relax validation for configuration without root disk device

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -134,16 +134,15 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("failed to stat kernel image path, %q: %v", cfg.KernelImagePath, err)
 	}
 
-	rootPath := ""
 	for _, drive := range cfg.Drives {
 		if BoolValue(drive.IsRootDevice) {
-			rootPath = StringValue(drive.PathOnHost)
+			rootPath := StringValue(drive.PathOnHost)
+			if _, err := os.Stat(rootPath); err != nil {
+				return fmt.Errorf("failed to stat host path, %q: %v", rootPath, err)
+			}
+
 			break
 		}
-	}
-
-	if _, err := os.Stat(rootPath); err != nil {
-		return fmt.Errorf("failed to stat host path, %q: %v", rootPath, err)
 	}
 
 	// Check the non-existence of some files:


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

If there's no root disk in the config, validation fails while trying to
stat path `""`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
