### PR TITLE
Allow passing VM interface name with CNI configuration

### DIFF
--- a/cni/vmconf/vmconf.go
+++ b/cni/vmconf/vmconf.go
@@ -53,6 +53,9 @@ type StaticNetworkConf struct {
 	// NetNSPath is the path to the bind-mounted network namespace in which the VM's
 	// tap device was created and thus where the VM should execute.
 	NetNSPath string
+	// VMIfName (optional) is interface name to configure. If left blank, config
+	// is applied to the first (default) interface.
+	VMIfName string
 
 	// VMMacAddr is the mac address that callers should configure their VM to use internally.
 	VMMacAddr string
@@ -117,9 +120,8 @@ func (c StaticNetworkConf) IPBootParam() string {
 	// the "hostname" field actually just configures a hostname value for DHCP requests, thus no need to set it
 	const dhcpHostname = ""
 
-	// TODO(sipsma) we are assuming there is only one network device
-	// Just use the only network device present in the VM
-	const device = ""
+	// If blank, use the only network device present in the VM
+	device := c.VMIfName
 
 	// Don't do any autoconfiguration (i.e. DHCP, BOOTP, RARP)
 	const autoconfiguration = "off"

--- a/cni/vmconf/vmconf_test.go
+++ b/cni/vmconf/vmconf_test.go
@@ -66,6 +66,7 @@ func TestIPBootParams(t *testing.T) {
 		TapName:   "taptaptap",
 		NetNSPath: "/my/lil/netns",
 		VMMacAddr: "00:11:22:33:44:55",
+		VMIfName:  "eth0",
 		VMMTU:     1337,
 		VMIPConfig: &current.IPConfig{
 			Version: "4",
@@ -88,7 +89,7 @@ func TestIPBootParams(t *testing.T) {
 		VMResolverOptions: []string{"choice", "is", "an", "illusion"},
 	}
 
-	expectedIPBootParam := "10.0.0.2::10.0.0.1:255.255.255.0:::off:1.1.1.1:8.8.8.8:"
+	expectedIPBootParam := "10.0.0.2::10.0.0.1:255.255.255.0::eth0:off:1.1.1.1:8.8.8.8:"
 	actualIPBootParam := staticNetworkConf.IPBootParam()
 	assert.Equal(t, expectedIPBootParam, actualIPBootParam)
 }

--- a/network.go
+++ b/network.go
@@ -158,6 +158,7 @@ func (networkInterfaces NetworkInterfaces) setupNetwork(
 				IPAddr:      vmNetConf.VMIPConfig.Address,
 				Gateway:     vmNetConf.VMIPConfig.Gateway,
 				Nameservers: vmNetConf.VMNameservers,
+				IfName:      cniNetworkInterface.CNIConfiguration.VMIfName,
 			}
 		}
 	}
@@ -240,6 +241,11 @@ type CNIConfiguration struct {
 	// created by a chained plugin that adapts the tap to a pre-existing
 	// network device (which will by the one with "IfName").
 	IfName string
+
+	// VMIfName (optional) sets the interface name in the VM. It is used
+	// to correctly pass IP configuration obtained from the CNI to the VM kernel.
+	// It can be left blank for VMs with single network interface.
+	VMIfName string
 
 	// Args (optional) corresponds to the CNI_ARGS parameter as specified in
 	// the CNI spec. It allows custom args to be passed to CNI plugins during
@@ -490,7 +496,8 @@ func (staticConf StaticNetworkConfiguration) validate() error {
 // IPConfiguration specifies an IP, a gateway and DNS Nameservers that should be configured
 // automatically within the VM upon boot. It currently only supports IPv4 addresses.
 //
-// IPConfiguration can currently only be specified for VM's with a single network interface.
+// IPConfiguration can specify interface name, in that case config will be applied to the
+// specified interface, if IfName is left blank, config applies to VM with a single network interface.
 // The IPAddr and Gateway will be used to assign an IP a a default route for the VM's internal
 // interface.
 //
@@ -502,6 +509,7 @@ type IPConfiguration struct {
 	IPAddr      net.IPNet
 	Gateway     net.IP
 	Nameservers []string
+	IfName      string
 }
 
 func (ipConf IPConfiguration) validate() error {
@@ -528,6 +536,7 @@ func (conf IPConfiguration) ipBootParam() string {
 			Address: conf.IPAddr,
 			Gateway: conf.Gateway,
 		},
+		VMIfName: conf.IfName,
 	}
 
 	return vmConf.IPBootParam()

--- a/network_test.go
+++ b/network_test.go
@@ -391,6 +391,7 @@ func newCNIMachine(t *testing.T,
 				CacheDir:    cniCacheDir,
 				NetworkName: networkName,
 				IfName:      ifName,
+				VMIfName:    "eth0",
 			},
 		}},
 		VMID: vmID,
@@ -415,6 +416,10 @@ func startCNIMachine(t *testing.T, ctx context.Context, m *Machine) string {
 	ipConfig := staticConfig.IPConfiguration
 	require.NotNil(t, ipConfig,
 		"cni configuration should have updated network interface ip configuration")
+
+	require.Equal(t, m.Cfg.NetworkInterfaces[0].CNIConfiguration.VMIfName,
+		staticConfig.IPConfiguration.IfName,
+		"interface name should be propagated to static conf")
 
 	return ipConfig.IPAddr.IP.String()
 }


### PR DESCRIPTION

*Issue #, if available:*

#173

*Description of changes:*

This allows passing `ip=` kernel configuration to the VM with interface
name set. In our case, kernel has bonding support enabled, so `bond0`
interface exists on boot, and it will be picked up for kernel
configuration unless `eth0` is specified explicitly in the configuration
line.

Change is backwards compatible, as interface name defaults to empty
string.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
