### PR TITLE
Add test step to test against HEAD of Firecracker

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,6 +32,17 @@ steps:
     commands:
       - 'sudo ip tuntap add fc-test-tap${BUILDKITE_BUILD_NUMBER} mode tap user $(sudo id -u buildkite-agent)'
       - 'sudo ip tuntap add fc-root-tap${BUILDKITE_BUILD_NUMBER} mode tap user $(sudo id -u buildkite-agent)'
+      - 'sudo ip tuntap add fc-mst-tap${BUILDKITE_BUILD_NUMBER} mode tap user $(sudo id -u buildkite-agent)'
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
+      distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
+      hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
+
+  - label: ':linux: build docker images'
+    commands:
+      - 'make test-images'
+      - 'buildkite-agent artifact upload testdata/firecracker-master'
+      - 'buildkite-agent artifact upload testdata/jailer-master'
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
@@ -91,6 +102,27 @@ steps:
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
 
+  - label: ':hammer: test against firecracker master'
+    env:
+      FC_TEST_BIN: "testdata/firecracker-master"
+      DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
+      FC_TEST_JAILER_BIN: "testdata/jailer-master"
+    commands:
+      - 'ln -s /var/lib/fc-ci/vmlinux.bin testdata/vmlinux'
+      - 'ln -s /var/lib/fc-ci/rootfs.ext4 testdata/root-drive.img'
+      - 'make -C cni install CNI_BIN_ROOT=$(pwd)/testdata/bin'
+      - 'buildkite-agent artifact download testdata/firecracker-master .'
+      - 'chmod +x testdata/firecracker-master'
+      - 'buildkite-agent artifact download testdata/jailer-master .'
+      - 'chmod +x testdata/jailer-master'
+      - "sudo -E FC_TEST_TAP=fc-mst-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS="
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
+      distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
+      hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
+    soft_fail:
+      - exit_status: "*"
+
 
   # This allows the cleanup step to always run, regardless of test failure
   - wait: ~
@@ -100,6 +132,7 @@ steps:
     commands:
       - 'sudo ip tuntap del fc-test-tap${BUILDKITE_BUILD_NUMBER} mode tap'
       - 'sudo ip tuntap del fc-root-tap${BUILDKITE_BUILD_NUMBER} mode tap'
+      - 'sudo ip tuntap del fc-mst-tap${BUILDKITE_BUILD_NUMBER} mode tap'
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 firecracker
 jailer
 firecracker-*
+jailer-*
 vmlinux
 root-drive.img
 TestPID.img

--- a/machine_test.go
+++ b/machine_test.go
@@ -231,25 +231,8 @@ func TestJailerMicroVMExecution(t *testing.T) {
 		}
 	}
 
-	jailerBin := defaultJailerBinary
-	if _, err := os.Stat(filepath.Join(testDataPath, defaultJailerBinary)); err == nil {
-		jailerBin = filepath.Join(testDataPath, defaultJailerBinary)
-	}
-
 	ctx := context.Background()
-	cmd := NewJailerCommandBuilder().
-		WithBin(jailerBin).
-		WithGID(IntValue(cfg.JailerCfg.GID)).
-		WithUID(IntValue(cfg.JailerCfg.UID)).
-		WithNumaNode(IntValue(cfg.JailerCfg.NumaNode)).
-		WithID(cfg.JailerCfg.ID).
-		WithChrootBaseDir(cfg.JailerCfg.ChrootBaseDir).
-		WithExecFile(cfg.JailerCfg.ExecFile).
-		WithStdout(os.Stdout).
-		WithStderr(os.Stderr).
-		Build(ctx)
-
-	m, err := NewMachine(ctx, cfg, WithProcessRunner(cmd), WithLogger(fctesting.NewLogEntry(t)))
+	m, err := NewMachine(ctx, cfg, WithLogger(fctesting.NewLogEntry(t)))
 	if err != nil {
 		t.Fatalf("failed to create new machine: %v", err)
 	}

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+FROM rust:1.39-stretch
+
+ENV DEBIAN_FRONTEND="noninteractive"
+RUN apt-get update && apt-get install --yes --no-install-recommends \
+  musl-tools
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+VOLUME /src
+
+RUN mkdir --mode=0777 --parents /usr/local/cargo/registry
+VOLUME /usr/local/cargo/registry
+
+RUN git clone https://github.com/firecracker-microvm/firecracker.git
+COPY tools/docker/entrypoint.sh /usr/local/bin
+WORKDIR firecracker
+ENTRYPOINT ["entrypoint.sh"]

--- a/tools/docker/entrypoint.sh
+++ b/tools/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cargo build --release --target $@
+cp build/cargo_target/x86_64-unknown-linux-musl/release/firecracker /artifacts/firecracker-master
+cp build/cargo_target/x86_64-unknown-linux-musl/release/jailer /artifacts/jailer-master


### PR DESCRIPTION
This change adds a test step in BuildKite to test against HEAD of
Firecracker. The test will utilize Docker to run against Firecracker's
master branch.

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
