### PR TITLE
Adds FC_TEST_JAILER_BIN to specify test jailer bin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -104,5 +104,3 @@ steps:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
-
-

--- a/machine_test.go
+++ b/machine_test.go
@@ -46,7 +46,8 @@ const (
 	firecrackerBinaryPath        = "firecracker"
 	firecrackerBinaryOverrideEnv = "FC_TEST_BIN"
 
-	defaultJailerBinary = "jailer"
+	defaultJailerBinary     = "jailer"
+	jailerBinaryOverrideEnv = "FC_TEST_JAILER_BIN"
 
 	defaultTuntapName = "fc-test-tap0"
 	tuntapOverrideEnv = "FC_TEST_TAP"
@@ -184,6 +185,7 @@ func TestJailerMicroVMExecution(t *testing.T) {
 			},
 		},
 		JailerCfg: &JailerConfig{
+			JailerBinary:   getJailerBinaryPath(),
 			GID:            Int(jailerGID),
 			UID:            Int(jailerUID),
 			NumaNode:       Int(0),
@@ -471,6 +473,13 @@ func getFirecrackerBinaryPath() string {
 		return val
 	}
 	return filepath.Join(testDataPath, firecrackerBinaryPath)
+}
+
+func getJailerBinaryPath() string {
+	if val := os.Getenv(jailerBinaryOverrideEnv); val != "" {
+		return val
+	}
+	return filepath.Join(testDataPath, defaultJailerBinary)
 }
 
 func getVmlinuxPath(t *testing.T) string {


### PR DESCRIPTION
This commit adds the FC_TEST_JAILER_BIN which allows user to specify
which jailer binary to use during testing.

Signed-off-by: xibz <impactbchang@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
