### PR TITLE
Fixes panic due to struct initiliaztion

### DIFF
--- a/fctesting/utils.go
+++ b/fctesting/utils.go
@@ -49,18 +49,18 @@ func RequiresRoot(t testing.TB) {
 
 func newLogger(t testing.TB) *log.Logger {
 	str := os.Getenv(logLevelEnvName)
+	l := log.New()
 	if str == "" {
-		return log.New()
+		return l
 	}
 
 	logLevel, err := log.ParseLevel(str)
 	if err != nil {
 		t.Fatalf("Failed to parse %q as Log Level: %v", str, err)
 	}
-	return &log.Logger{
-		Out:   os.Stdout,
-		Level: logLevel,
-	}
+
+	l.SetLevel(logLevel)
+	return l
 }
 
 // NewLogEntry creates log.Entry. The level is specified by "FC_TEST_LOG_LEVEL" environment variable

--- a/fctesting/utils_test.go
+++ b/fctesting/utils_test.go
@@ -1,0 +1,18 @@
+package fctesting
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoggingPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Error(r)
+		}
+	}()
+
+	os.Setenv("FC_TEST_LOG_LEVEL", "debug")
+	l := NewLogEntry(t)
+	l.Debug("TestLoggingPanic")
+}


### PR DESCRIPTION
This would panic due to not setting up default arguments such as the
Formatter in the logger when using the FC_TEST_LOG_LEVEL. This fix
instead uses log.New() to have the necessary bootstrapping occur and
sets the necessary fields as needed.

Signed-off-by: xibz <impactbchang@gmail.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
