### PR TITLE
Rename "cargocache" volume since firecracker-containerd is using the same volume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 # Set this to pass additional commandline flags to the go compiler, e.g. "make test EXTRAGOARGS=-v"
-CARGO_CACHE_VOLUME_NAME?=cargocache
+CARGO_CACHE_VOLUME_NAME?=firecracker-go-sdk--cargocache
 DISABLE_ROOT_TESTS?=1
 DOCKER_IMAGE_TAG?=latest
 EXTRAGOARGS:=

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ FIRECRACKER_BIN=testdata/firecracker-master
 JAILER_BIN=testdata/jailer-master
 FIRECRACKER_TARGET?=x86_64-unknown-linux-musl
 
+UID = $(shell id -u)
+GID = $(shell id -g)
+
 # The below files are needed and can be downloaded from the internet
 testdata_objects = testdata/vmlinux testdata/root-drive.img testdata/firecracker
 
@@ -70,18 +73,18 @@ test-images: $(FIRECRACKER_BIN) $(JAILER_BIN)
 
 $(FIRECRACKER_BIN) $(JAILER_BIN): tools/firecracker-builder-stamp
 	docker run --rm -it \
-		--privileged \
+		--user $(UID):$(GID) \
 		--volume $(CURDIR)/testdata:/artifacts \
 		--volume $(CARGO_CACHE_VOLUME_NAME):/usr/local/cargo/registry \
 		-e HOME=/tmp \
 		--workdir=/firecracker \
 		localhost/$(FIRECRACKER_BUILDER_NAME):$(DOCKER_IMAGE_TAG) \
-		$(FIRECRACKER_TARGET)	
+		$(FIRECRACKER_TARGET)
 
 .PHONY: firecracker-clean
 firecracker-clean:
 	- docker run --rm -it \
-		--privileged \
+		--user $(UID):$(GID) \
 		--workdir /firecracker\
 		localhost/$(FIRECRACKER_BUILDER_NAME):$(DOCKER_IMAGE_TAG) \
 		cargo clean

--- a/tools/docker/entrypoint.sh
+++ b/tools/docker/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-cargo build --release --target $@
-cp build/cargo_target/x86_64-unknown-linux-musl/release/firecracker /artifacts/firecracker-master
-cp build/cargo_target/x86_64-unknown-linux-musl/release/jailer /artifacts/jailer-master
+cargo build --release --target-dir=/artifacts --target $@
+cp /artifacts/x86_64-unknown-linux-musl/release/firecracker /artifacts/firecracker-master
+cp /artifacts/x86_64-unknown-linux-musl/release/jailer /artifacts/jailer-master


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

firecracker-containerd sometimes cannot build Firecracker, probably due to the fact that Go SDK uses "cargocache" volume as root.

While we can change the run-as user to make both of them compatible, I'd like to rather getting rid of dependencies between 2 projects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
