### PR TITLE
Fix firecracker-clean target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ jailer-*
 vmlinux
 root-drive.img
 TestPID.img
+build/
+

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -25,6 +25,4 @@ RUN mkdir --mode=0777 --parents /usr/local/cargo/registry
 VOLUME /usr/local/cargo/registry
 
 RUN git clone https://github.com/firecracker-microvm/firecracker.git
-COPY tools/docker/entrypoint.sh /usr/local/bin
 WORKDIR firecracker
-ENTRYPOINT ["entrypoint.sh"]

--- a/tools/docker/entrypoint.sh
+++ b/tools/docker/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-cargo build --release --target-dir=/artifacts --target $@
-cp /artifacts/x86_64-unknown-linux-musl/release/firecracker /artifacts/firecracker-master
-cp /artifacts/x86_64-unknown-linux-musl/release/jailer /artifacts/jailer-master


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

entrypoint.sh assumes that the parameters are for "cargo build ...",
which doesn't work with firecracker-clean target.

Instead of fixing the shell script, this change makes the container
itself more neutral by accepting any arbitrary commands.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
