### PR TITLE
stopVMM: don't signal if stopped

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -23,6 +23,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -576,9 +577,13 @@ func (m *Machine) StopVMM() error {
 }
 
 func (m *Machine) stopVMM() error {
-	if m.cmd != nil && m.cmd.Process != nil && m.cmd.ProcessState == nil {
+	if m.cmd != nil && m.cmd.Process != nil {
 		m.logger.Debug("stopVMM(): sending sigterm to firecracker")
-		return m.cmd.Process.Signal(syscall.SIGTERM)
+		err := m.cmd.Process.Signal(syscall.SIGTERM)
+		if err != nil && !strings.Contains(err.Error(), "os: process already finished") {
+			return err
+		}
+		return nil
 	}
 	m.logger.Debug("stopVMM(): no firecracker process running, not sending a signal")
 

--- a/machine.go
+++ b/machine.go
@@ -576,7 +576,7 @@ func (m *Machine) StopVMM() error {
 }
 
 func (m *Machine) stopVMM() error {
-	if m.cmd != nil && m.cmd.Process != nil {
+	if m.cmd != nil && m.cmd.Process != nil && m.cmd.ProcessState == nil {
 		m.logger.Debug("stopVMM(): sending sigterm to firecracker")
 		return m.cmd.Process.Signal(syscall.SIGTERM)
 	}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/firecracker-microvm/firecracker-go-sdk/issues/200

*Description of changes:*

1. Turn `TestWait/StopVMM_+_Context_Cancel` into a failing test case: after the VM is terminated (via exit(0) or signal) and context is cancelled, an error is logged.
1. Patch `machine.stopVMM()` to not send `SIGTERM` if we've already seen the process has exited.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
