### PR TITLE
Download Firecracker 0.21.1 and its jailer from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ UID = $(shell id -u)
 GID = $(shell id -g)
 
 # The below files are needed and can be downloaded from the internet
-testdata_objects = testdata/vmlinux testdata/root-drive.img testdata/firecracker
+testdata_objects = testdata/vmlinux testdata/root-drive.img testdata/firecracker testdata/jailer
 
 # --location is needed to follow redirects on github.com
 curl = curl --location
@@ -58,7 +58,11 @@ testdata/vmlinux:
 	$(curl) -o $@ https://s3.amazonaws.com/spec.ccfc.min/img/hello/kernel/hello-vmlinux.bin
 
 testdata/firecracker:
-	$(curl) -o $@ https://github.com/firecracker-microvm/firecracker/releases/download/v0.18.0/firecracker-v0.18.0
+	$(curl) -o $@ https://github.com/firecracker-microvm/firecracker/releases/download/v0.21.1/firecracker-v0.21.1-x86_64
+	chmod +x $@
+
+testdata/jailer:
+	$(curl) -o $@ https://github.com/firecracker-microvm/firecracker/releases/download/v0.21.1/jailer-v0.21.1-x86_64
 	chmod +x $@
 
 testdata/root-drive.img:


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

These rules were added to easily start developing the SDK, but it
hasn't been updated since 0.18.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
