### PR TITLE
Don't hard-code machine api socket path, use value from machine config

### DIFF
--- a/jailer.go
+++ b/jailer.go
@@ -30,6 +30,8 @@ const (
 	defaultJailerBin  = "jailer"
 
 	rootfsFolderName = "root"
+
+	defaultSocketPath = "/run/firecracker.socket"
 )
 
 var (
@@ -288,7 +290,14 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
 		jailerWorkspaceDir = filepath.Join(defaultJailerPath, filepath.Base(cfg.JailerCfg.ExecFile), cfg.JailerCfg.ID, rootfsFolderName)
 	}
 
-	cfg.SocketPath = filepath.Join(jailerWorkspaceDir, "run", "firecracker.socket")
+	var machineSocketPath string
+	if cfg.SocketPath != "" {
+		machineSocketPath = cfg.SocketPath
+	} else {
+		machineSocketPath = defaultSocketPath
+	}
+
+	cfg.SocketPath = filepath.Join(jailerWorkspaceDir, machineSocketPath)
 
 	stdout := cfg.JailerCfg.Stdout
 	if stdout == nil {
@@ -310,6 +319,7 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
 		WithDaemonize(cfg.JailerCfg.Daemonize).
 		WithFirecrackerArgs(
 			"--seccomp-level", cfg.SeccompLevel.String(),
+			"--api-sock", machineSocketPath,
 		).
 		WithStdout(stdout).
 		WithStderr(stderr)

--- a/jailer.go
+++ b/jailer.go
@@ -299,7 +299,13 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
 
 	cfg.SocketPath = filepath.Join(jailerWorkspaceDir, machineSocketPath)
 
-	if err := os.MkdirAll(filepath.Dir(cfg.SocketPath), 0600); err != nil {
+	jailedSocketBasePath := filepath.Dir(cfg.SocketPath)
+
+	if err := os.MkdirAll(jailedSocketBasePath, 0600); err != nil {
+		return err
+	}
+
+	if err := os.Chown(jailedSocketBasePath, *m.Cfg.JailerCfg.UID, *m.Cfg.JailerCfg.GID); err != nil {
 		return err
 	}
 

--- a/jailer.go
+++ b/jailer.go
@@ -21,6 +21,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 const (
@@ -302,11 +304,11 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
 	jailedSocketBasePath := filepath.Dir(cfg.SocketPath)
 
 	if err := os.MkdirAll(jailedSocketBasePath, 0600); err != nil {
-		return err
+		return errors.Wrap(err, "failed to create socket path directories")
 	}
 
 	if err := os.Chown(jailedSocketBasePath, *m.Cfg.JailerCfg.UID, *m.Cfg.JailerCfg.GID); err != nil {
-		return err
+		return errors.Wrap(err, "failed to chown socket path directories")
 	}
 
 	stdout := cfg.JailerCfg.Stdout

--- a/jailer.go
+++ b/jailer.go
@@ -307,7 +307,7 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
 		return errors.Wrap(err, "failed to create socket path directories")
 	}
 
-	if err := os.Chown(jailedSocketBasePath, *m.Cfg.JailerCfg.UID, *m.Cfg.JailerCfg.GID); err != nil {
+	if err := os.Chown(jailedSocketBasePath, *cfg.JailerCfg.UID, *cfg.JailerCfg.GID); err != nil {
 		return errors.Wrap(err, "failed to chown socket path directories")
 	}
 

--- a/jailer.go
+++ b/jailer.go
@@ -299,6 +299,10 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
 
 	cfg.SocketPath = filepath.Join(jailerWorkspaceDir, machineSocketPath)
 
+	if err := os.MkdirAll(filepath.Dir(cfg.SocketPath), 0600); err != nil {
+		return err
+	}
+
 	stdout := cfg.JailerCfg.Stdout
 	if stdout == nil {
 		stdout = os.Stdout

--- a/jailer_test.go
+++ b/jailer_test.go
@@ -156,6 +156,7 @@ func TestJail(t *testing.T) {
 		jailerCfg        JailerConfig
 		expectedArgs     []string
 		netns            string
+		socketPath       string
 		expectedSockPath string
 	}{
 		{
@@ -183,6 +184,8 @@ func TestJail(t *testing.T) {
 				"--",
 				"--seccomp-level",
 				"0",
+				"--api-sock",
+				"/run/firecracker.socket",
 			},
 			expectedSockPath: filepath.Join(
 				defaultJailerPath,
@@ -218,6 +221,8 @@ func TestJail(t *testing.T) {
 				"--",
 				"--seccomp-level",
 				"0",
+				"--api-sock",
+				"/run/firecracker.socket",
 			},
 			expectedSockPath: filepath.Join(
 				defaultJailerPath,
@@ -259,6 +264,8 @@ func TestJail(t *testing.T) {
 				"--",
 				"--seccomp-level",
 				"0",
+				"--api-sock",
+				"/run/firecracker.socket",
 			},
 			expectedSockPath: filepath.Join(
 				"/tmp",
@@ -267,6 +274,42 @@ func TestJail(t *testing.T) {
 				rootfsFolderName,
 				"run",
 				"firecracker.socket"),
+		},
+		{
+			name:       "custom socket path",
+			socketPath: "api.sock",
+			jailerCfg: JailerConfig{
+				ID:             "my-test-id",
+				UID:            Int(123),
+				GID:            Int(100),
+				NumaNode:       Int(0),
+				ChrootStrategy: NewNaiveChrootStrategy("path", "kernel-image-path"),
+				ExecFile:       "/path/to/firecracker",
+			},
+			expectedArgs: []string{
+				defaultJailerBin,
+				"--id",
+				"my-test-id",
+				"--uid",
+				"123",
+				"--gid",
+				"100",
+				"--exec-file",
+				"/path/to/firecracker",
+				"--node",
+				"0",
+				"--",
+				"--seccomp-level",
+				"0",
+				"--api-sock",
+				"api.sock",
+			},
+			expectedSockPath: filepath.Join(
+				defaultJailerPath,
+				"firecracker",
+				"my-test-id",
+				rootfsFolderName,
+				"api.sock"),
 		},
 	}
 	for _, c := range testCases {
@@ -277,8 +320,9 @@ func TestJail(t *testing.T) {
 				},
 			}
 			cfg := &Config{
-				JailerCfg: &c.jailerCfg,
-				NetNS:     c.netns,
+				JailerCfg:  &c.jailerCfg,
+				NetNS:      c.netns,
+				SocketPath: c.socketPath,
 			}
 			jail(context.Background(), m, cfg)
 

--- a/jailer_test.go
+++ b/jailer_test.go
@@ -277,7 +277,7 @@ func TestJail(t *testing.T) {
 		},
 		{
 			name:       "custom socket path",
-			socketPath: "api.sock",
+			socketPath: "/api/firecracker.sock",
 			jailerCfg: JailerConfig{
 				ID:             "my-test-id",
 				UID:            Int(123),
@@ -302,14 +302,14 @@ func TestJail(t *testing.T) {
 				"--seccomp-level",
 				"0",
 				"--api-sock",
-				"api.sock",
+				"/api/firecracker.sock",
 			},
 			expectedSockPath: filepath.Join(
 				defaultJailerPath,
 				"firecracker",
 				"my-test-id",
 				rootfsFolderName,
-				"api.sock"),
+				"/api/firecracker.sock"),
 		},
 	}
 	for _, c := range testCases {

--- a/machine.go
+++ b/machine.go
@@ -76,6 +76,7 @@ var ErrAlreadyStarted = errors.New("firecracker: machine already started")
 type Config struct {
 	// SocketPath defines the file path where the Firecracker control socket
 	// should be created.
+	// Note: if used with the jailer, this path is relative to the jail
 	SocketPath string
 
 	// LogFifo defines the file path where the Firecracker log named-pipe should

--- a/machine_test.go
+++ b/machine_test.go
@@ -157,7 +157,7 @@ func TestJailerMicroVMExecution(t *testing.T) {
 	jailerFullRootPath := filepath.Join(jailerTestPath, filepath.Base(getFirecrackerBinaryPath()), id)
 	os.MkdirAll(jailerTestPath, 0777)
 
-	socketPath := "TestJailerMicroVMExecution.socket"
+	socketPath := "/api/TestJailerMicroVMExecution.socket"
 	logFifo := filepath.Join(tmpDir, "firecracker.log")
 	metricsFifo := filepath.Join(tmpDir, "firecracker-metrics")
 	capturedLog := filepath.Join(tmpDir, "writer.fifo")

--- a/machine_test.go
+++ b/machine_test.go
@@ -157,7 +157,7 @@ func TestJailerMicroVMExecution(t *testing.T) {
 	jailerFullRootPath := filepath.Join(jailerTestPath, filepath.Base(getFirecrackerBinaryPath()), id)
 	os.MkdirAll(jailerTestPath, 0777)
 
-	socketPath := filepath.Join(jailerTestPath, "firecracker", "TestJailerMicroVMExecution.socket")
+	socketPath := "TestJailerMicroVMExecution.socket"
 	logFifo := filepath.Join(tmpDir, "firecracker.log")
 	metricsFifo := filepath.Join(tmpDir, "firecracker-metrics")
 	capturedLog := filepath.Join(tmpDir, "writer.fifo")
@@ -167,7 +167,7 @@ func TestJailerMicroVMExecution(t *testing.T) {
 		fw.Close()
 		exec.Command("cp", capturedLog, logPath).Run()
 		os.Remove(capturedLog)
-		os.Remove(socketPath)
+		os.Remove(filepath.Join(jailerTestPath, "firecracker", socketPath))
 		os.Remove(logFifo)
 		os.Remove(metricsFifo)
 		os.RemoveAll(tmpDir)


### PR DESCRIPTION
Issue: #217 

*Description of changes:*

Uses machine's `SocketPath` instead of always using the default `/run/firecracker.socket`, allowing for shorter paths.