### PR TITLE
cni/cmd/tc-redirect-tap: fix dropped test error

### DIFF
--- a/cni/cmd/tc-redirect-tap/main_test.go
+++ b/cni/cmd/tc-redirect-tap/main_test.go
@@ -365,6 +365,7 @@ func TestNewPlugin(t *testing.T) {
 		},
 	}
 	rawPrevResultBytes, err := json.Marshal(netConf)
+	require.NoError(t, err, "failed to marshal JSON")
 	testArgs := skel.CmdArgs{
 		ContainerID: "continer-id",
 		Netns:       nspath,


### PR DESCRIPTION
Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>

This fixes a dropped `err` variable in the tests for `cni/cmd/tc-redirect-tap`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
