### PR TITLE
Clarify error message when host drive path is inaccessible

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -177,7 +177,7 @@ func (cfg *Config) Validate() error {
 		if BoolValue(drive.IsRootDevice) {
 			rootPath := StringValue(drive.PathOnHost)
 			if _, err := os.Stat(rootPath); err != nil {
-				return fmt.Errorf("failed to stat host path, %q: %v", rootPath, err)
+				return fmt.Errorf("failed to stat host drive path, %q: %v", rootPath, err)
 			}
 
 			break


### PR DESCRIPTION
Example with firectl:

```
$ ./firectl --kernel=./vmlinux
WARN[0000] Failed handler "validate.Cfg": failed to stat host path, "": stat : no such file or directory
FATA[0000] Failed to start machine: failed to stat host path, "": stat : no such file or directory
```

As you can see it's rather impossible for the user to tell what exactly is missing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
