### PR TITLE
Upgrade Rust from 1.39 to 1.43.1

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-FROM rust:1.39-stretch
+FROM rust:1.43.1-buster
 
 ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update && apt-get install --yes --no-install-recommends \


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

Firecracker uses 1.43.1 since
https://github.com/firecracker-microvm/firecracker/commit/2397f6a24041870c7fa7d41b0715a5aa8e2f97db.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
