### PR TITLE
firecracker: fix dropped test errors

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -759,7 +759,13 @@ func TestLogFiles(t *testing.T) {
 	stdoutPath := filepath.Join(testDataPath, "stdout.log")
 	stderrPath := filepath.Join(testDataPath, "stderr.log")
 	stdout, err := os.Create(stdoutPath)
+	if err != nil {
+		t.Fatalf("error creating %q: %v", stdoutPath, err)
+	}
 	stderr, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("error creating %q: %v", stderrPath, err)
+	}
 
 	fd, err := net.Listen("unix", cfg.SocketPath)
 	if err != nil {


### PR DESCRIPTION
This logs and handles two dropped test errors in the `firecracker` package.