### PR TITLE
Use Config.VMID as Firecracker's instance ID

### DIFF
--- a/jailer_test.go
+++ b/jailer_test.go
@@ -320,6 +320,7 @@ func TestJail(t *testing.T) {
 				},
 			}
 			cfg := &Config{
+				VMID:       "vmid",
 				JailerCfg:  &c.jailerCfg,
 				NetNS:      c.netns,
 				SocketPath: c.socketPath,


### PR DESCRIPTION
Firecracker is internally has an instance ID, but the SDK didn't have
the way to configure the ID. This change connects Config.VMID to the
instance ID.

*Issue #, if available:*

NA

*Description of changes:*

* Connects Config.VMID to Firecracker's Instance ID.
* Alternatively we can add Config.InstanceID but I think that would be too confusing.
* Renaming VMID to InstanceID is another option and has less impedance mismatch, but I don't want to break existing customers, including firecracker-containerd.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
