### PR TITLE
Setting a logger without its level

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -616,9 +616,16 @@ func (m *Machine) setupLogging(ctx context.Context) error {
 		return nil
 	}
 
+	// m.Cfg.LogLevel cannot be nil, but Firecracker allows setting a logger
+	// without its level. Converting "" to nil to support the corner case.
+	level := String(m.Cfg.LogLevel)
+	if StringValue(level) == "" {
+		level = nil
+	}
+
 	l := models.Logger{
 		LogPath:       String(path),
-		Level:         String(m.Cfg.LogLevel),
+		Level:         level,
 		ShowLevel:     Bool(true),
 		ShowLogOrigin: Bool(false),
 	}

--- a/machine_test.go
+++ b/machine_test.go
@@ -424,6 +424,7 @@ func TestLogAndMetrics(t *testing.T) {
 		logLevel string
 		quiet    bool
 	}{
+		{logLevel: "", quiet: false},
 		{logLevel: "Info", quiet: false},
 		{logLevel: "Error", quiet: true},
 	}
@@ -432,9 +433,15 @@ func TestLogAndMetrics(t *testing.T) {
 			out := testLogAndMetrics(t, test.logLevel)
 			if test.quiet {
 				assert.Regexp(t, `^Running Firecracker v0\.\d+\.0`, out)
-			} else {
-				assert.Contains(t, string(out), ":"+strings.ToUpper(test.logLevel)+"]")
+				return
 			}
+
+			// By default, Firecracker's log level is Warn.
+			logLevel := "WARN"
+			if test.logLevel != "" {
+				logLevel = strings.ToUpper(test.logLevel)
+			}
+			assert.Contains(t, out, ":"+logLevel+"]")
 		})
 	}
 }


### PR DESCRIPTION
This may not have an real use-case, but Firecracker supports
the combination.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

NA

*Description of changes:*

Setting a logger without its level possible by converting "" to nil, since it's string's zero value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
