### PR TITLE
Build firecracker and jailer explictly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,8 @@ $(FIRECRACKER_BIN) $(JAILER_BIN): tools/firecracker-builder-stamp
 		--workdir=/firecracker \
 		localhost/$(FIRECRACKER_BUILDER_NAME):$(DOCKER_IMAGE_TAG) \
 		cargo build --release \
-		--target-dir=/artifacts --target $(FIRECRACKER_TARGET)
+		--target-dir=/artifacts --target $(FIRECRACKER_TARGET) \
+		-p firecracker -p jailer
 	cp build/$(FIRECRACKER_TARGET)/release/firecracker $(FIRECRACKER_BIN)
 	cp build/$(FIRECRACKER_TARGET)/release/jailer $(JAILER_BIN)
 


### PR DESCRIPTION
Since https://github.com/firecracker-microvm/firecracker/pull/2125,
`cargo build` doesn't build jailer by default.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
