### PR TITLE
readme: fix broken security link

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ to report problems, discuss roadmap items, or make feature requests.
 If you've discovered an issue that may have security implications to
 users or developers of this software, please do not report it using
 GitHub issues, but instead follow
-[Firecracker's security reporting guidelines](https://github.com/firecracker-microvm/firecracker/blob/master/SECURITY-POLICY.md).
+[Firecracker's security reporting guidelines](https://github.com/firecracker-microvm/firecracker/blob/master/SECURITY.md).
 
 Other discussion: For general discussion, please join us in the
 `#general` channel on the [Firecracker Slack](https://tinyurl.com/firecracker-microvm).


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/firecracker-microvm/firecracker-go-sdk/issues/283

*Description of changes:*
Firecracker moved their security policy document to SECURITY.md so that GitHub would recognize the project security policy automatically.  See https://github.com/firecracker-microvm/firecracker/commit/ce1ee597c10026d753a39454b79dfe17d26d20f9.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
