### PR TITLE
Remove root-owned files

### DIFF
--- a/.buildkite/hooks/pre-checkout
+++ b/.buildkite/hooks/pre-checkout
@@ -1,4 +1,0 @@
-#! /bin/sh
-set -euo pipefail
-
-find . -user root -print0 | xargs -0 sudo rm -rf '{}'

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Since some tests are running as root, they may create root-owned files.
+# These files cannot be deleted by BuildKite Agent since the agent is running
+# as non-root.
 set -euo pipefail
 
-find . -user root -print0 | xargs -0 sudo rm -rf '{}'
+files=$(sudo sh -c "find $BUILDKITE_BUILD_CHECKOUT_PATH -user root -print0 | xargs -0 rm -rfv '{}'")
+
+# If the command above removes files, show and exit with 1.
+echo "$files" | tr "\0" "\n"
+test -z "$files"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -101,18 +101,20 @@ steps:
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
 
   - label: ':hammer: root tests'
+    key: root
     commands:
       - 'ln -s /var/lib/fc-ci/vmlinux.bin testdata/vmlinux'
       - 'ln -s /var/lib/fc-ci/rootfs.ext4 testdata/root-drive.img'
       - 'mkdir -p $(pwd)/testdata/bin'
       - 'GOBIN=$(pwd)/testdata/bin go get github.com/awslabs/tc-redirect-tap/cmd/tc-redirect-tap'
-      - "sudo PATH=$PATH FC_TEST_TAP=fc-root-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS="
+      - make test EXTRAGOARGS="-v -count=1 -race -exec $PWD/.buildkite/sudo.sh" DISABLE_ROOT_TESTS=
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
 
   - label: ':hammer: test against firecracker master'
+    key: mst
     env:
       FC_TEST_BIN: "testdata/firecracker-master"
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
@@ -127,7 +129,7 @@ steps:
       # Install tc-redirect-tap.
       - 'mkdir -p testdata/bin'
       - 'GOBIN=$(pwd)/testdata/bin go get github.com/awslabs/tc-redirect-tap/cmd/tc-redirect-tap'
-      - "sudo -E PATH=$PATH FC_TEST_TAP=fc-mst-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS="
+      - make test EXTRAGOARGS="-v -count=1 -race -exec $PWD/.buildkite/sudo.sh" DISABLE_ROOT_TESTS=
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -113,6 +113,21 @@ steps:
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
 
+  - label: 'go mod tidy'
+    commands:
+      - 'go mod tidy'
+      - test -z "$(git status --porcelain)" && exit 0 || git --no-pager diff && echo -e '\ngo.mod and/or go.sum differ from committed, please run "go mod tidy" and commit the updated files.\n' && exit 42
+    soft_fail:
+      - exit_status: 42 # Dependabot doesn't modify go.mod and go.sum
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
+      distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
+      hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
+
+  # Network-related tests on the root tests above will conflict with the master tests below,
+  # since both of them use the same IP addresses.
+  - wait
+
   - label: ':hammer: test against firecracker master'
     key: mst
     env:
@@ -130,17 +145,6 @@ steps:
       - 'mkdir -p testdata/bin'
       - 'GOBIN=$(pwd)/testdata/bin go get github.com/awslabs/tc-redirect-tap/cmd/tc-redirect-tap'
       - make test EXTRAGOARGS="-v -count=1 -race -exec $PWD/.buildkite/sudo.sh" DISABLE_ROOT_TESTS=
-    agents:
-      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
-      distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
-      hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
-
-  - label: 'go mod tidy'
-    commands:
-      - 'go mod tidy'
-      - test -z "$(git status --porcelain)" && exit 0 || git --no-pager diff && echo -e '\ngo.mod and/or go.sum differ from committed, please run "go mod tidy" and commit the updated files.\n' && exit 42
-    soft_fail:
-      - exit_status: 42 # Dependabot doesn't modify go.mod and go.sum
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"

--- a/.buildkite/sudo.sh
+++ b/.buildkite/sudo.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+set -euo pipefail
+
+sudo -E \
+     PATH=$PATH \
+     FC_TEST_TAP=fc-$BUILDKITE_STEP_KEY-tap$BUILDKITE_BUILD_NUMBER \
+     "$@"


### PR DESCRIPTION
Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*

We run some tests as root user whereas BuildKite's agent is running as non-root due to security concerns. Because of the mismatch, we sometimes have files that cannot be deleted from BuildKite's agent.

This PR does the following, which is larger than what I had expected:
- Clean up files from tests correctly
- Update .buildkite/pipeline.yml to download binaries as non-root
- Update .buildkite/hooks/pre-exit to find files as root
- Remove .buildkite/hooks/pre-checkout, since the hook cannot be executed before cloning this Git repos, which is too late.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
