### PR TITLE
Run tests on GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,5 +25,5 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
-    - name: Build
-      run: make build
+    - name: Test
+      run: make test EXTRAGOARGS=-v

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         go: ['1.11', '1.12', '1.13', '1.14', '1.15']
         os: ['ubuntu-20.04']
-
+      fail-fast: false
     name: ${{ matrix.os }} / Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ['1.11', '1.12', '1.13', '1.14', '1.15']
+        go: ['1.11', '1.12', '1.13', '1.14', '1.15', '1.16']
         os: ['ubuntu-20.04']
       fail-fast: false
     name: ${{ matrix.os }} / Go ${{ matrix.go }}

--- a/Makefile
+++ b/Makefile
@@ -48,15 +48,11 @@ all: build
 
 test: all-tests
 
-unit-tests: check-kvm $(testdata_objects)
+unit-tests: $(testdata_objects)
 	DISABLE_ROOT_TESTS=$(DISABLE_ROOT_TESTS) go test -short ./... $(EXTRAGOARGS)
 
-all-tests: check-kvm $(testdata_objects)
+all-tests: $(testdata_objects)
 	DISABLE_ROOT_TESTS=$(DISABLE_ROOT_TESTS) go test ./... $(EXTRAGOARGS)
-
-check-kvm:
-	@test -w /dev/kvm || \
-		(echo "In order to run firecracker, $(shell whoami) must have write permission to /dev/kvm"; false)
 
 generate build clean::
 	go $@ $(EXTRAGOARGS)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.0
 	github.com/sparrc/go-ping v0.0.0-20190613174326-4e5b6552494c
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.6.1
 	github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852
 	golang.org/x/sys v0.0.0-20201117170446-d9b008d0a637
 )

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,6 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=

--- a/machine_test.go
+++ b/machine_test.go
@@ -122,9 +122,7 @@ func TestNewMachine(t *testing.T) {
 }
 
 func TestJailerMicroVMExecution(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
+	fctesting.RequiresKVM(t)
 	fctesting.RequiresRoot(t)
 
 	logPath := filepath.Join(testDataLogPath, "TestJailerMicroVMExecution")
@@ -284,9 +282,7 @@ func TestJailerMicroVMExecution(t *testing.T) {
 }
 
 func TestMicroVMExecution(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
+	fctesting.RequiresKVM(t)
 
 	var nCpus int64 = 2
 	cpuTemplate := models.CPUTemplate(models.CPUTemplateT2)
@@ -398,8 +394,11 @@ func TestMicroVMExecution(t *testing.T) {
 }
 
 func TestStartVMM(t *testing.T) {
+	fctesting.RequiresKVM(t)
+
 	socketPath, cleanup := makeSocketPath(t)
 	defer cleanup()
+
 	cfg := Config{
 		SocketPath: socketPath,
 	}
@@ -437,6 +436,8 @@ func TestStartVMM(t *testing.T) {
 }
 
 func TestLogAndMetrics(t *testing.T) {
+	fctesting.RequiresKVM(t)
+
 	tests := []struct {
 		logLevel string
 		quiet    bool
@@ -523,6 +524,8 @@ func testLogAndMetrics(t *testing.T, logLevel string) string {
 }
 
 func TestStartVMMOnce(t *testing.T) {
+	fctesting.RequiresKVM(t)
+
 	socketPath, cleanup := makeSocketPath(t)
 	defer cleanup()
 
@@ -1252,6 +1255,7 @@ func TestCaptureFifoToFile_leak(t *testing.T) {
 }
 
 func TestWait(t *testing.T) {
+	fctesting.RequiresKVM(t)
 	fctesting.RequiresRoot(t)
 
 	cases := []struct {
@@ -1535,6 +1539,7 @@ func TestSignalForwarding(t *testing.T) {
 }
 
 func TestPauseResume(t *testing.T) {
+	fctesting.RequiresKVM(t)
 	fctesting.RequiresRoot(t)
 
 	dir, err := ioutil.TempDir("", t.Name())
@@ -1646,6 +1651,7 @@ func TestPauseResume(t *testing.T) {
 }
 
 func TestCreateSnapshot(t *testing.T) {
+	fctesting.RequiresKVM(t)
 	fctesting.RequiresRoot(t)
 
 	dir, err := ioutil.TempDir("", t.Name())


### PR DESCRIPTION
While GitHub Actions' environment doesn't have KVM, we can run
a few tests on there to make sure that the SDK works with different
Go versions.

It doesn't run Firecracker, but running some tests is better than
running no tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
