### PR TITLE
Fix InitrdPath usage

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -63,7 +63,7 @@ var JailerConfigValidationHandler = Handler{
 			return nil
 		}
 
-		hasRoot := false
+		hasRoot := m.Cfg.InitrdPath != ""
 		for _, drive := range m.Cfg.Drives {
 			if BoolValue(drive.IsRootDevice) {
 				hasRoot = true

--- a/jailer.go
+++ b/jailer.go
@@ -373,7 +373,7 @@ func LinkFilesHandler(kernelImageFileName string) Handler {
 
 			initrdFilename := ""
 			if m.Cfg.InitrdPath != "" {
-				initrdFilename := filepath.Base(m.Cfg.InitrdPath)
+				initrdFilename = filepath.Base(m.Cfg.InitrdPath)
 				// copy initrd to root fs
 				if err := os.Link(
 					m.Cfg.InitrdPath,


### PR DESCRIPTION
*Description of changes:*

The way `InitrdPath` was implemented is buggy:

- When you set a `initrd_path` with firecracker, [you do not want a root drive](https://github.com/firecracker-microvm/firecracker/issues/186#issuecomment-725957979).
- There was a type (I believe that's what it was) which prevented `initrdFilename` to ever be set to anything other than `""`. This would make the config for `InitrdPath` useless.

With both these changes, I was able to use `initrd_path` successfully.