### PR TITLE
Use GitHub's native Dependabot to support "go mod tidy"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+


### PR DESCRIPTION
We've been using Dependabot (dependabot-preview) for upgrading Go
modules. However dependabot-preview has been replaced by the
GitHub-native Dependabot which supports "go mod tidy"!

This change introduces GitHub-native Dependabot by adding its new
configuration file.

https://dependabot.com/docs/config-file/
https://github.blog/changelog/2020-10-19-dependabot-go-mod-tidy-and-vendor-support/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
