### PR TITLE
Make go mod tidy mandatory

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -131,9 +131,7 @@ steps:
   - label: 'go mod tidy'
     commands:
       - 'go mod tidy'
-      - test -z "$(git status --porcelain)" && exit 0 || git --no-pager diff && echo -e '\ngo.mod and/or go.sum differ from committed, please run "go mod tidy" and commit the updated files.\n' && exit 42
-    soft_fail:
-      - exit_status: 42 # Dependabot doesn't modify go.mod and go.sum
+      - test -z "$(git status --porcelain)" && exit 0 || git --no-pager diff && echo -e '\ngo.mod and/or go.sum differ from committed, please run "go mod tidy" and commit the updated files.\n' && exit 1
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"


### PR DESCRIPTION
Since Dependabot is now able to run "go mod tidy", we can make it
mandatory on all changes.

https://github.blog/changelog/2020-10-19-dependabot-go-mod-tidy-and-vendor-support/

*Issue #, if available:*

NA

*Description of changes:*

Update BuildKite's configuration to make sure "go mod tidy" doesn't modify anything.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
