### PR TITLE
Update download link for kernel, firecracker and jailer

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -431,7 +431,7 @@ func TestLogAndMetrics(t *testing.T) {
 		t.Run(test.logLevel, func(t *testing.T) {
 			out := testLogAndMetrics(t, test.logLevel)
 			if test.quiet {
-				assert.Regexp(t, `^Running Firecracker v0\.\d+\.0`, out)
+				assert.Regexp(t, `^Running Firecracker v0\.\d+\.\d+`, out)
 				return
 			}
 


### PR DESCRIPTION
Signed-off-by: Royce Zhao <qiqinzha@amazon.com>

*Issue #, if available:*

*Description of changes:*
Update the download link for kernel, firecracker and jailer in Makefile to keep consistent with Firecracker team. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
