### PR TITLE
fix use of (*T).Fatalf from non testing goroutine

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -770,7 +770,8 @@ func TestWaitForSocket(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 		_, err := os.Create(filename)
 		if err != nil {
-			t.Fatalf("Unable to create test file %s: %s", filename, err)
+			t.Errorf("Unable to create test file %s: %s", filename, err)
+			return
 		}
 	}()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Using t.Fatalf in the goroutine will only exit the goroutine. Use
t.Errorf instead to return failure to the testing function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
