### PR TITLE
Add describeInstance functionality for reading vm info

### DIFF
--- a/firecracker.go
+++ b/firecracker.go
@@ -358,6 +358,22 @@ func (f *Client) GetMachineConfiguration(opts ...GetMachineConfigurationOpt) (*o
 	return f.client.Operations.GetMachineConfiguration(p)
 }
 
+// DescribeInstanceOpt is a functional option to be used for the DescribeInstance API
+// for any additional optional fields
+type DescribeInstanceOpt func(*ops.DescribeInstanceParams)
+
+// GetInstanceInfo is a wrapper for the swagger generated client to make calling of
+// the API easier
+func (f *Client) GetInstanceInfo(ctx context.Context, opts ...DescribeInstanceOpt) (*ops.DescribeInstanceOK, error) {
+	params := ops.NewDescribeInstanceParams()
+	params.SetContext(ctx)
+	for _, opt := range opts {
+		opt(params)
+	}
+
+	return f.client.Operations.DescribeInstance(params)
+}
+
 // PatchGuestDriveByIDOpt is a functional option to be used for the PutMmds API in setting
 // any additional optional fields.
 type PatchGuestDriveByIDOpt func(*ops.PatchGuestDriveByIDParams)

--- a/machine.go
+++ b/machine.go
@@ -946,6 +946,23 @@ func (m *Machine) UpdateGuestDrive(ctx context.Context, driveID, pathOnHost stri
 	return nil
 }
 
+func (m *Machine) DescribeInstanceInfo(ctx context.Context) (models.InstanceInfo, error) {
+	var instanceInfo models.InstanceInfo
+	resp, err := m.client.GetInstanceInfo(ctx)
+	if err != nil {
+		m.logger.Errorf("Getting Instance Info: %s", err)
+		return instanceInfo, err
+	}
+
+	instanceInfo = *resp.Payload
+	if err != nil {
+		m.logger.Errorf("Getting Instance info failed parsing payload: %s", err)
+	}
+
+	m.logger.Printf("GetInstanceInfo successful")
+	return instanceInfo, err
+}
+
 // refreshMachineConfiguration synchronizes our cached representation of the machine configuration
 // with that reported by the Firecracker API
 func (m *Machine) refreshMachineConfiguration() error {

--- a/machine_test.go
+++ b/machine_test.go
@@ -375,6 +375,7 @@ func TestMicroVMExecution(t *testing.T) {
 	t.Run("UpdateMetadata", func(t *testing.T) { testUpdateMetadata(ctx, t, m) })
 	t.Run("GetMetadata", func(t *testing.T) { testGetMetadata(ctx, t, m) }) // Should be after testSetMetadata and testUpdateMetadata
 	t.Run("TestStartInstance", func(t *testing.T) { testStartInstance(ctx, t, m) })
+	t.Run("TestGetInstanceInfo", func(t *testing.T) { testGetInstanceInfo(ctx, t, m) })
 
 	// Let the VMM start and stabilize...
 	timer := time.NewTimer(5 * time.Second)
@@ -833,6 +834,29 @@ func testGetMetadata(ctx context.Context, t *testing.T, m *Machine) {
 
 	if metadata.Key != "value" || metadata.PatchKey != "patch_value" {
 		t.Error("failed to get expected metadata values")
+	}
+}
+
+func testGetInstanceInfo(ctx context.Context, t *testing.T, m *Machine) {
+	instance, err := m.DescribeInstanceInfo(ctx)
+	if err != nil {
+		t.Error("failed to get instance info")
+	}
+
+	if instance.AppName == nil || *instance.AppName == "" {
+		t.Error("Invalid instance App name")
+	}
+
+	if instance.ID == nil || *instance.ID == "" {
+		t.Error("Invalid instance ID")
+	}
+
+	if instance.State == nil || *instance.State == "" {
+		t.Error("Invalid instance state")
+	}
+
+	if instance.VmmVersion == nil || *instance.VmmVersion == "" {
+		t.Error("Invalid VmmVersion")
 	}
 }
 


### PR DESCRIPTION
This will help use cases where we need to check guest's running state
and other information before taking another action.

Signed-off-by: Alakesh Haloi <alakeshh@amazon.com>

*Issue #, if available:*

*Description of changes:*

Getting running state of the VM from firecracker is needed many use cases. Implementing DescribeInstance similar to how GetMetadata is implemented.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
