### PR TITLE
Rename master to main

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -116,10 +116,10 @@ steps:
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
 
-  - label: ':hammer: test against firecracker master'
+  - label: ':hammer: test against firecracker main'
     env:
-      FC_TEST_BIN: "${FC_TEST_DATA_PATH}/firecracker-master"
-      FC_TEST_JAILER_BIN: "${FC_TEST_DATA_PATH}/jailer-master"
+      FC_TEST_BIN: "${FC_TEST_DATA_PATH}/firecracker-main"
+      FC_TEST_JAILER_BIN: "${FC_TEST_DATA_PATH}/jailer-main"
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
     commands:
       - "sudo -E PATH=$PATH FC_TEST_TAP=fc-mst-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS="

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ reported the issue. Please try to include as much information as you can. Detail
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
@@ -56,6 +56,7 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/firecracker-microvm/firecracker-go-sdk/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/firecracker-microvm/firecracker-go-sdk/blob/main/LICENSE) file for
+our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ FIRECRACKER_BUILDER_NAME=firecracker-builder
 FIRECRACKER_TARGET?=x86_64-unknown-linux-musl
 
 FC_TEST_DATA_PATH?=testdata
-FIRECRACKER_BIN=$(FC_TEST_DATA_PATH)/firecracker-master
-JAILER_BIN=$(FC_TEST_DATA_PATH)/jailer-master
+FIRECRACKER_BIN=$(FC_TEST_DATA_PATH)/firecracker-main
+JAILER_BIN=$(FC_TEST_DATA_PATH)/jailer-main
 
 UID = $(shell id -u)
 GID = $(shell id -g)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 A basic Go interface to the Firecracker API
 ====
 
-[![Build status](https://badge.buildkite.com/de08ca676829bedbf6de040c2c2ba1a5d2892e220997c2abdd.svg?branch=master)](https://buildkite.com/firecracker-microvm/firecracker-go-sdk)
+[![Build status](https://badge.buildkite.com/de08ca676829bedbf6de040c2c2ba1a5d2892e220997c2abdd.svg?branch=main)](https://buildkite.com/firecracker-microvm/firecracker-go-sdk)
 [![GoDoc](https://godoc.org/github.com/firecracker-microvm/firecracker-go-sdk?status.svg)](https://godoc.org/github.com/firecracker-microvm/firecracker-go-sdk)
 
 This package is a Go library to interact with the Firecracker API. It
@@ -160,7 +160,7 @@ to report problems, discuss roadmap items, or make feature requests.
 If you've discovered an issue that may have security implications to
 users or developers of this software, please do not report it using
 GitHub issues, but instead follow
-[Firecracker's security reporting guidelines](https://github.com/firecracker-microvm/firecracker/blob/master/SECURITY.md).
+[Firecracker's security reporting guidelines](https://github.com/firecracker-microvm/firecracker/blob/main/SECURITY.md).
 
 Other discussion: For general discussion, please join us in the
 `#general` channel on the [Firecracker Slack](https://tinyurl.com/firecracker-microvm).


### PR DESCRIPTION
We no longer use `master` in the SDK and Firecracker.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
