### PR TITLE
Update Firecracker from v0.24.2 to v0.24.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ JAILER_BIN=$(FC_TEST_DATA_PATH)/jailer-main
 UID = $(shell id -u)
 GID = $(shell id -g)
 
-firecracker_version=v0.24.2
+firecracker_version=v0.24.3
 arch=$(shell uname -m)
 
 # The below files are needed and can be downloaded from the internet

--- a/client/models/balloon.go
+++ b/client/models/balloon.go
@@ -30,9 +30,9 @@ import (
 // swagger:model Balloon
 type Balloon struct {
 
-	// Target balloon size in MB.
+	// Target balloon size in MiB.
 	// Required: true
-	AmountMb *int64 `json:"amount_mb"`
+	AmountMib *int64 `json:"amount_mib"`
 
 	// Whether the balloon should deflate when the guest has memory pressure.
 	// Required: true
@@ -46,7 +46,7 @@ type Balloon struct {
 func (m *Balloon) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateAmountMb(formats); err != nil {
+	if err := m.validateAmountMib(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -60,9 +60,9 @@ func (m *Balloon) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *Balloon) validateAmountMb(formats strfmt.Registry) error {
+func (m *Balloon) validateAmountMib(formats strfmt.Registry) error {
 
-	if err := validate.Required("amount_mb", "body", m.AmountMb); err != nil {
+	if err := validate.Required("amount_mib", "body", m.AmountMib); err != nil {
 		return err
 	}
 

--- a/client/models/balloon_stats.go
+++ b/client/models/balloon_stats.go
@@ -30,9 +30,9 @@ import (
 // swagger:model BalloonStats
 type BalloonStats struct {
 
-	// Actual amount of memory (in MB) the device is holding.
+	// Actual amount of memory (in MiB) the device is holding.
 	// Required: true
-	ActualMb *int64 `json:"actual_mb"`
+	ActualMib *int64 `json:"actual_mib"`
 
 	// Actual number of pages the device is holding.
 	// Required: true
@@ -65,9 +65,9 @@ type BalloonStats struct {
 	// The amount of memory that has been swapped out to disk (in bytes).
 	SwapOut int64 `json:"swap_out,omitempty"`
 
-	// Target amount of memory (in MB) the device aims to hold.
+	// Target amount of memory (in MiB) the device aims to hold.
 	// Required: true
-	TargetMb *int64 `json:"target_mb"`
+	TargetMib *int64 `json:"target_mib"`
 
 	// Target number of pages the device aims to hold.
 	// Required: true
@@ -81,7 +81,7 @@ type BalloonStats struct {
 func (m *BalloonStats) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateActualMb(formats); err != nil {
+	if err := m.validateActualMib(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -89,7 +89,7 @@ func (m *BalloonStats) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateTargetMb(formats); err != nil {
+	if err := m.validateTargetMib(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -103,9 +103,9 @@ func (m *BalloonStats) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *BalloonStats) validateActualMb(formats strfmt.Registry) error {
+func (m *BalloonStats) validateActualMib(formats strfmt.Registry) error {
 
-	if err := validate.Required("actual_mb", "body", m.ActualMb); err != nil {
+	if err := validate.Required("actual_mib", "body", m.ActualMib); err != nil {
 		return err
 	}
 
@@ -121,9 +121,9 @@ func (m *BalloonStats) validateActualPages(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *BalloonStats) validateTargetMb(formats strfmt.Registry) error {
+func (m *BalloonStats) validateTargetMib(formats strfmt.Registry) error {
 
-	if err := validate.Required("target_mb", "body", m.TargetMb); err != nil {
+	if err := validate.Required("target_mib", "body", m.TargetMib); err != nil {
 		return err
 	}
 

--- a/client/models/balloon_update.go
+++ b/client/models/balloon_update.go
@@ -30,16 +30,16 @@ import (
 // swagger:model BalloonUpdate
 type BalloonUpdate struct {
 
-	// Target balloon size in MB.
+	// Target balloon size in MiB.
 	// Required: true
-	AmountMb *int64 `json:"amount_mb"`
+	AmountMib *int64 `json:"amount_mib"`
 }
 
 // Validate validates this balloon update
 func (m *BalloonUpdate) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateAmountMb(formats); err != nil {
+	if err := m.validateAmountMib(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -49,9 +49,9 @@ func (m *BalloonUpdate) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *BalloonUpdate) validateAmountMb(formats strfmt.Registry) error {
+func (m *BalloonUpdate) validateAmountMib(formats strfmt.Registry) error {
 
-	if err := validate.Required("amount_mb", "body", m.AmountMb); err != nil {
+	if err := validate.Required("amount_mib", "body", m.AmountMib); err != nil {
 		return err
 	}
 

--- a/client/models/drive.go
+++ b/client/models/drive.go
@@ -30,9 +30,6 @@ import (
 // swagger:model Drive
 type Drive struct {
 
-	// Represents the caching strategy for the block device.
-	CacheType *string `json:"cache_type,omitempty"`
-
 	// drive id
 	// Required: true
 	DriveID *string `json:"drive_id"`

--- a/client/swagger.yaml
+++ b/client/swagger.yaml
@@ -5,7 +5,7 @@ info:
     The API is accessible through HTTP calls on specific URLs
     carrying JSON modeled data.
     The transport medium is a Unix Domain Socket.
-  version: 0.24.0
+  version: 0.24.3
   termsOfService: ""
   contact:
     email: "compute-capsule@amazon.com"
@@ -617,14 +617,14 @@ definitions:
   Balloon:
     type: object
     required:
-      - amount_mb
+      - amount_mib
       - deflate_on_oom
     description:
       Balloon device descriptor.
     properties:
-      amount_mb:
+      amount_mib:
         type: integer
-        description: Target balloon size in MB.
+        description: Target balloon size in MiB.
       deflate_on_oom:
         type: boolean
         description: Whether the balloon should deflate when the guest has memory pressure.
@@ -635,13 +635,13 @@ definitions:
   BalloonUpdate:
     type: object
     required:
-      - amount_mb
+      - amount_mib
     description:
       Balloon device descriptor.
     properties:
-      amount_mb:
+      amount_mib:
         type: integer
-        description: Target balloon size in MB.
+        description: Target balloon size in MiB.
 
   BalloonStats:
     type: object
@@ -650,8 +650,8 @@ definitions:
     required:
       - target_pages
       - actual_pages
-      - target_mb
-      - actual_mb
+      - target_mib
+      - actual_mib
     properties:
       target_pages:
         description: Target number of pages the device aims to hold.
@@ -659,11 +659,11 @@ definitions:
       actual_pages:
         description: Actual number of pages the device is holding.
         type: integer
-      target_mb:
-        description: Target amount of memory (in MB) the device aims to hold.
+      target_mib:
+        description: Target amount of memory (in MiB) the device aims to hold.
         type: integer
-      actual_mb:
-        description: Actual amount of memory (in MB) the device is holding.
+      actual_mib:
+        description: Actual amount of memory (in MiB) the device is holding.
         type: integer
       swap_in:
         description: The amount of memory that has been swapped in (in bytes).
@@ -753,11 +753,6 @@ definitions:
     properties:
       drive_id:
         type: string
-      cache_type:
-        type: string
-        description:
-          Represents the caching strategy for the block device.
-        default: "Unsafe"
       is_read_only:
         type: boolean
       is_root_device:
@@ -1089,3 +1084,4 @@ definitions:
         description: Path to UNIX domain socket, used to proxy vsock connections.
       vsock_id:
         type: string
+


### PR DESCRIPTION
Firecracker v0.24.3 is now released, and we should update our Firecracker as well. This release fix
the balloon API: All "MB" change to "MiB".

This is a patch release introducing the following changes:
· Changed Docker images repository from DockerHub to Amazon ECR.
· Snapshot related host files (vm-state, memory, block backing files) are now flushed to their backing mediums as part of the CreateSnapshot operation.
· ​Fixed ballooning API definition by renaming all fields which mentioned "MB" to use "MiB" instead.

Signed-off-by: Royce Zhao <qiqinzha@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
