### PR TITLE
Allow cni runtime capabilities to be configuratble from CNIConfiguration

### DIFF
--- a/network.go
+++ b/network.go
@@ -239,6 +239,13 @@ type CNIConfiguration struct {
 	// configuration directory.
 	NetworkConfig *libcni.NetworkConfigList
 
+	// CapabilityArgs (optional) is a dictionary of capability-specific
+	// data passed by the runtime to plugins as top-level keys in the
+	// 'runtimeConfig' dictionary of the plugin's stdin data. libcni
+	// will ensure that only keys in this map which match the capabilities
+	// of the plugin are passed to the plugin.
+	CapabilityArgs map[string]interface{}
+
 	// IfName (optional) corresponds to the CNI_IFNAME parameter as specified
 	// in the CNI spec. It generally specifies the name of the interface to be
 	// created by a CNI plugin being invoked.
@@ -316,10 +323,11 @@ func (cniConf *CNIConfiguration) setDefaults() {
 
 func (cniConf CNIConfiguration) asCNIRuntimeConf() *libcni.RuntimeConf {
 	return &libcni.RuntimeConf{
-		ContainerID: cniConf.containerID,
-		NetNS:       cniConf.netNSPath,
-		IfName:      cniConf.IfName,
-		Args:        cniConf.Args,
+		ContainerID:    cniConf.containerID,
+		NetNS:          cniConf.netNSPath,
+		IfName:         cniConf.IfName,
+		Args:           cniConf.Args,
+		CapabilityArgs: cniConf.CapabilityArgs,
 	}
 }
 

--- a/network_test.go
+++ b/network_test.go
@@ -290,7 +290,11 @@ func testNetworkMachineCNI(t *testing.T, useConfFile bool) {
     },
     {
       "type": "tc-redirect-tap"
-    }
+    },
+		{
+			"type": "portmap",
+			"capabilities": {"portMappings": true}
+		}
   ]
 }`, networkName)
 
@@ -424,6 +428,15 @@ func newCNIMachine(t *testing.T,
 				NetworkConfig: networkConf,
 				IfName:        ifName,
 				VMIfName:      "eth0",
+				CapabilityArgs: map[string]interface{}{
+					"portMappings": []interface{}{
+						map[string]interface{}{
+							"hostPort":      8080,
+							"containerPort": 80,
+							"protocol":      "tcp",
+						},
+					},
+				},
 			},
 		}},
 		VMID: vmID,


### PR DESCRIPTION
Introduce CapabilityArgs into the CNIConfiguration to allow CNI runtime capabilities to be
configurable from the firecracker-go-sdk.

Here are a few useful use cases: https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#well-known-capabilities

Signed-off-by: Jingkai He <jingkai@hey.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
