### PR TITLE
Drop Go 1.11 and 1.12

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         go: ['1.13', '1.14', '1.15', '1.16', '1.17']
-        os: ['ubuntu-20.04']
+        os: ['ubuntu-18.04', 'ubuntu-20.04']
       fail-fast: false
     name: ${{ matrix.os }} / Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
go.mongodb.org/mongo-driver < 1.5.1 has a vulnerability. While the SDK
won't be affected, having the old mongo-driver package makes automated
security notificaion systems (incl. GitHub's) unhappy.

This change removes old Go versions from GitHub Actions before
updating our dependencies. Go 1.11 and 1.12 are no longer supported by
the Go team and many packages don't work on the versions anymore.

https://github.com/advisories/GHSA-f6mq-5m25-4r72

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
