### PR TITLE
Make TestLogAndMetrics work with Firecracker's main branch

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -461,7 +461,9 @@ func TestLogAndMetrics(t *testing.T) {
 		t.Run(test.logLevel, func(t *testing.T) {
 			out := testLogAndMetrics(t, test.logLevel)
 			if test.quiet {
-				assert.Regexp(t, `^Running Firecracker v0\.\d+\.\d+`, out)
+				// Non-released versions have version strings like
+				// "v0.26-wip-145-g6cbffe0d".
+				assert.Regexp(t, `^Running Firecracker v\d+\.\d+[\.-]`, out)
 				return
 			}
 


### PR DESCRIPTION
Non-released versions have version strings like
"v0.26-wip-145-g6cbffe0d".

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
