### PR TITLE
Drop Go 1.13

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ['1.13', '1.14', '1.15', '1.16', '1.17']
+        go: ['1.14', '1.15', '1.16', '1.17']
         os: ['ubuntu-18.04', 'ubuntu-20.04']
       fail-fast: false
     name: ${{ matrix.os }} / Go ${{ matrix.go }}


### PR DESCRIPTION
github.com/go-openapi/runtime's latest version doesn't work with Go
1.13 due to net/http.

Since Go 1.13 is no longer maintained by the Go team, it would be
better to just drop the version rather than asking the package owner
to support the version.

https://pkg.go.dev/net/http#Header.Values

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
