### PR TITLE
Upgrade Go from 1.13 to 1.15

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 env:
-  PATH: "/usr/lib/go-1.13/bin:/usr/bin"
+  PATH: "/usr/lib/go-1.15/bin:/usr/bin"
   FC_TEST_DATA_PATH: "/tmp/buildkite_build_${BUILDKITE_BUILD_NUMBER}_testdata"
 
 steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,6 +127,10 @@ steps:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
+    # Firecracker's main branch wouldn't work with Go SDK currently due to ht_enabled change.
+    # https://github.com/firecracker-microvm/firecracker/pull/2876
+    soft_fail:
+      - exit_status: 2
 
   - label: 'go mod tidy'
     commands:


### PR DESCRIPTION
- The first commit is upgrading Go from 1.13 to 1.15. `go-openapi` needs Go 1.15, which we probably should adopt rather than stop updating. Go 1.15 and Go 1.13 are no longer supported according to https://go.dev/doc/devel/release. We need to discuss #364 later.
- The second commit is making Firecracker's main branch build "soft fail", meaning that the build breakage wouldn't make the whole build broken. Firecracker is making some breaking changes before 1.0. So we cannot make the SDK work with the main branch and released versions.