### PR TITLE
isTemporaryNetErr didn't work when the error was wrapped

### DIFF
--- a/vsock/dial.go
+++ b/vsock/dial.go
@@ -239,6 +239,10 @@ func (e connectMsgError) Temporary() bool {
 	return false
 }
 
+func (e connectMsgError) Timeout() bool {
+	return false
+}
+
 type ackError struct {
 	cause error
 }
@@ -251,13 +255,12 @@ func (e ackError) Temporary() bool {
 	return true
 }
 
-// isTemporaryNetErr returns whether the provided error is a retriable
-// error, according to the interface defined here:
-// https://golang.org/pkg/net/#Error
-func isTemporaryNetErr(err error) bool {
-	terr, ok := err.(interface {
-		Temporary() bool
-	})
+func (e ackError) Timeout() bool {
+	return false
+}
 
-	return err != nil && ok && terr.Temporary()
+// isTemporaryNetErr returns whether the provided error is a retriable error.
+func isTemporaryNetErr(err error) bool {
+	var netError net.Error
+	return err != nil && errors.As(err, &netError) && netError.Temporary()
 }

--- a/vsock/dial_test.go
+++ b/vsock/dial_test.go
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package vsock
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemporaryNetErr(t *testing.T) {
+	assert.True(t, isTemporaryNetErr(&ackError{cause: errors.New("ack")}))
+
+	assert.False(t, isTemporaryNetErr(&connectMsgError{cause: errors.New("connect")}))
+	assert.False(t, isTemporaryNetErr(errors.New("something else")))
+	assert.False(t, isTemporaryNetErr(nil))
+}


### PR DESCRIPTION
The fix was based on the below PR, but slightly changed to use net.Error
as is.

https://github.com/firecracker-microvm/firecracker-containerd/pull/583

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
