### PR TITLE
Do not soft-fail on Firecracker's main branch build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,10 +127,6 @@ steps:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
-    # Firecracker's main branch wouldn't work with Go SDK currently due to ht_enabled change.
-    # https://github.com/firecracker-microvm/firecracker/pull/2876
-    soft_fail:
-      - exit_status: 2
 
   - label: 'go mod tidy'
     commands:


### PR DESCRIPTION
Since 2380785, the SDK should work with Firecracker's main branch.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
