### PR TITLE
Remove pkg/errors

### DIFF
--- a/cni/internal/cniutil.go
+++ b/cni/internal/cniutil.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 
 	current "github.com/containernetworking/cni/pkg/types/100"
-	"github.com/pkg/errors"
 )
 
 // InterfaceIPs returns the IPs associated with the interface possessing the provided name and
@@ -78,8 +77,7 @@ func VMTapPair(
 ) {
 	vmIfaces, otherIfaces := FilterBySandbox(vmID, result.Interfaces...)
 	if len(vmIfaces) > 1 {
-		return nil, nil, errors.Errorf(
-			"expected to find at most 1 interface in sandbox %q, but instead found %d",
+		return nil, nil, fmt.Errorf("expected to find at most 1 interface in sandbox %q, but instead found %d",
 			vmID, len(vmIfaces))
 	} else if len(vmIfaces) == 0 {
 		return nil, nil, LinkNotFoundError{device: fmt.Sprintf("pseudo-device for %s", vmID)}
@@ -94,8 +92,7 @@ func VMTapPair(
 
 	tapIfaces := IfacesWithName(tapName, otherIfaces...)
 	if len(tapIfaces) > 1 {
-		return nil, nil, errors.Errorf(
-			"expected to find at most 1 interface with name %q, but instead found %d",
+		return nil, nil, fmt.Errorf("expected to find at most 1 interface with name %q, but instead found %d",
 			tapName, len(tapIfaces))
 	} else if len(tapIfaces) == 0 {
 		return nil, nil, LinkNotFoundError{device: tapName}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mdlayher/vsock v1.1.1
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5

--- a/machine.go
+++ b/machine.go
@@ -16,6 +16,7 @@ package firecracker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -33,7 +34,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
+
 	log "github.com/sirupsen/logrus"
 
 	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
@@ -320,7 +321,7 @@ func NewMachine(ctx context.Context, cfg Config, opts ...Opt) (*Machine, error) 
 	if cfg.VMID == "" {
 		id, err := uuid.NewRandom()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create random ID for VMID")
+			return nil, fmt.Errorf("failed to create random ID for VMID: %w", err)
 		}
 		cfg.VMID = id.String()
 	}
@@ -549,7 +550,7 @@ func (m *Machine) startVMM(ctx context.Context) error {
 	// Wait for firecracker to initialize:
 	err = m.waitForSocket(time.Duration(m.client.firecrackerInitTimeout)*time.Second, errCh)
 	if err != nil {
-		err = errors.Wrapf(err, "Firecracker did not create API socket %s", m.Cfg.SocketPath)
+		err = fmt.Errorf("Firecracker did not create API socket %s: %w", m.Cfg.SocketPath, err)
 		m.fatalErr = err
 		close(m.exitCh)
 

--- a/vsock/listener.go
+++ b/vsock/listener.go
@@ -15,11 +15,11 @@ package vsock
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
 	"github.com/mdlayher/vsock"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -64,11 +64,11 @@ func (l listener) Accept() (net.Conn, error) {
 		case <-tickerCh:
 			conn, err := tryAccept(logger, l.listener, l.port)
 			if isTemporaryNetErr(err) {
-				err = errors.Wrap(err, "temporary vsock accept failure")
+				err = fmt.Errorf("temporary vsock accept failure: %w", err)
 				logger.WithError(err).Debug()
 				continue
 			} else if err != nil {
-				err = errors.Wrap(err, "non-temporary vsock accept failure")
+				err = fmt.Errorf("non-temporary vsock accept failure: %w", err)
 				logger.WithError(err).Error()
 				return nil, err
 			}


### PR DESCRIPTION
This commit removes the package with the help of
https://github.com/xdg-go/go-rewrap-errors.

fmt.Errorf() can wrap errors nowadays.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
