### PR TITLE
Added API functionality + testing to get Firecracker Version

### DIFF
--- a/firecracker.go
+++ b/firecracker.go
@@ -75,6 +75,22 @@ func NewClient(socketPath string, logger *logrus.Entry, debug bool, opts ...Clie
 	return c
 }
 
+// GetFirecrackerVersionOpt is a functional option to be used for the
+// GetFirecrackerVersion API in setting any additional optional fields.
+type GetFirecrackerVersionOpt func(*ops.GetFirecrackerVersionParams)
+
+// GetFirecrackerVersion is a wrapper for the swagger generated client to make
+// calling of the API easier.
+func (f *Client) GetFirecrackerVersion(ctx context.Context, opts ...GetFirecrackerVersionOpt) (*ops.GetFirecrackerVersionOK, error) {
+	params := ops.NewGetFirecrackerVersionParams()
+	params.SetContext(ctx)
+	for _, opt := range opts {
+		opt(params)
+	}
+
+	return f.client.Operations.GetFirecrackerVersion(params)
+}
+
 // PutLoggerOpt is a functional option to be used for the PutLogger API in
 // setting any additional optional fields.
 type PutLoggerOpt func(*ops.PutLoggerParams)

--- a/firecracker_test.go
+++ b/firecracker_test.go
@@ -20,6 +20,7 @@ import (
 
 	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
 	"github.com/firecracker-microvm/firecracker-go-sdk/fctesting"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClient(t *testing.T) {
@@ -63,4 +64,39 @@ func TestClient(t *testing.T) {
 	if _, err := client.PutGuestDriveByID(ctx, "test", drive); err != nil {
 		t.Errorf("unexpected error on PutGuestDriveByID, %v", err)
 	}
+}
+
+func TestGetFirecrackerVersion(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := context.Background()
+	socketpath, cleanup := makeSocketPath(t)
+	defer cleanup()
+
+	cmd := VMCommandBuilder{}.
+		WithBin(getFirecrackerBinaryPath()).
+		WithSocketPath(socketpath).
+		Build(ctx)
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start firecracker vmm: %v", err)
+	}
+
+	defer func() {
+		if err := cmd.Process.Kill(); err != nil {
+			t.Errorf("failed to kill process: %v", err)
+		}
+	}()
+
+	client := NewClient(socketpath, fctesting.NewLogEntry(t), true)
+	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer deadlineCancel()
+	if err := waitForAliveVMM(deadlineCtx, client); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := client.GetFirecrackerVersion(ctx)
+	require.NoError(t, err, "failed to get firecracker version")
 }

--- a/machine.go
+++ b/machine.go
@@ -429,6 +429,18 @@ func (m *Machine) Wait(ctx context.Context) error {
 	}
 }
 
+// GetFirecrackerVersion gets the machine's firecracker version and returns it
+func (m *Machine) GetFirecrackerVersion(ctx context.Context) (string, error) {
+	resp, err := m.client.GetFirecrackerVersion(ctx)
+	if err != nil {
+		m.logger.Errorf("Getting firecracker version: %s", err)
+		return "", err
+	}
+
+	m.logger.Debug("GetFirecrackerVersion successful")
+	return *resp.Payload.FirecrackerVersion, nil
+}
+
 func (m *Machine) setupNetwork(ctx context.Context) error {
 	err, cleanupFuncs := m.Cfg.NetworkInterfaces.setupNetwork(ctx, m.Cfg.VMID, m.Cfg.NetNS, m.logger)
 	m.cleanupFuncs = append(m.cleanupFuncs, cleanupFuncs...)


### PR DESCRIPTION
Added the ability for users to get the current version of Firecracker being used, and added tests in both firecracker_test.go and machine_test.go.

Functions were added in where it made some logical sense to me. If it's not consistent with the overall structure please let me know, as I couldn't seem to get the exact structure of the order of the functions in the files. Also, please pay attention to how I tested the function in machine_test.go, as I'm not super confident that's where it should be, but it feels right.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.