### PR TITLE
Added API functionality + testing to change engine IO type

### DIFF
--- a/drives.go
+++ b/drives.go
@@ -110,3 +110,12 @@ func WithCacheType(cacheType string) DriveOpt {
 		d.CacheType = String(cacheType)
 	}
 }
+
+// WithIoEngine sets the io engine of the drive
+// Defaults to Sync, Async is in developer preview at the moment
+// https://github.com/firecracker-microvm/firecracker/blob/v1.1.0/docs/api_requests/block-io-engine.md
+func WithIoEngine(ioEngine string) DriveOpt {
+	return func(d *models.Drive) {
+		d.IoEngine = String(ioEngine)
+	}
+}

--- a/drives_test.go
+++ b/drives_test.go
@@ -155,3 +155,23 @@ func TestDrivesBuilderAddDrive(t *testing.T) {
 		t.Errorf("expected drives %+v\n, but received %+v", e, a)
 	}
 }
+
+func TestDrivesBuilderWithIoEngine(t *testing.T) {
+	expectedPath := "/path/to/rootfs"
+	expectedVal := "Async"
+	expectedDrives := []models.Drive{
+		{
+			DriveID:      String(rootDriveName),
+			PathOnHost:   &expectedPath,
+			IsRootDevice: Bool(true),
+			IsReadOnly:   Bool(false),
+			IoEngine:     &expectedVal,
+		},
+	}
+
+	drives := NewDrivesBuilder(expectedPath).WithRootDrive(expectedPath,
+		WithDriveID(string(rootDriveName)), WithIoEngine(expectedVal)).Build()
+	if e, a := expectedDrives, drives; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected drives %+v, but received %+v", e, a)
+	}
+}


### PR DESCRIPTION
The Drive model has a variable called `IoEngine` that determines if the block device runs commands synchronously or asynchronously (default synchronous). This PR implements a function to change said variable alongside a test to show that it works.

The default value seems to be nil and I assume that the handling of that is done in Firecracker itself, but if this is not the case, please let me know.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
