### PR TITLE
chore: cleanup stamp on firecracker clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ clean::
 
 distclean: clean
 	rm -rf $(testdata_objects)
+	rm -f $(FC_TEST_DATA_PATH)/fc.stamp
 	rm -rfv $(testdata_dir)
 	docker volume rm -f $(CARGO_CACHE_VOLUME_NAME)
 


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:*
N/A

*Description of changes:*
Cleanup stamp file on firecracker clean so binaries can be re-downloaded again.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
