### PR TITLE
Add concurrency test to install step in pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,6 +65,11 @@ steps:
   - wait
 
   - label: ':package: install'
+    # This concurrency group can be removed when one of the below issues are resolved:
+    # https://github.com/firecracker-microvm/firecracker-go-sdk/issues/418
+    # https://github.com/firecracker-microvm/firecracker/issues/3058
+    concurrency_group: "mount rootfs"
+    concurrency: 1
     env:
       GOBIN: "$FC_TEST_DATA_PATH/bin"
     commands:


### PR DESCRIPTION
Signed-off-by: David Son <davbson@amazon.com>

*Issue #, if available:*

*Description of changes:*
Added concurrency test to install step in the BuildKite pipeline to reduce/remove flakiness in testing.

The flakiness seems to be due to an issue on Firecracker's end, so if that issue is resolved, this PR can be reverted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
