### PR TITLE
Added mount directory to build_rootfs command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ $(FC_TEST_DATA_PATH)/root-drive-ssh-key $(FC_TEST_DATA_PATH)/root-drive-with-ssh
 # Need root to move ssh key to testdata location
 ifeq ($(GID), 0)
 	$(MAKE) $(FIRECRACKER_DIR)
-	$(FIRECRACKER_DIR)/tools/devtool build_rootfs
+	$(FIRECRACKER_DIR)/tools/devtool build_rootfs -m $(FC_TEST_DATA_PATH)/mnt
 	cp $(FIRECRACKER_DIR)/build/rootfs/bionic.rootfs.ext4 $(FC_TEST_DATA_PATH)/root-drive-with-ssh.img
 	cp $(FIRECRACKER_DIR)/build/rootfs/ssh/id_rsa $(FC_TEST_DATA_PATH)/root-drive-ssh-key
 	rm -rf $(FIRECRACKER_DIR)


### PR DESCRIPTION
Signed-off-by: David Son <son.david.b@gmail.com>

*Issue #, if available:*

*Description of changes:*
Firecracker's `build_rootfs` command now supports [specifying a mount directory](https://github.com/firecracker-microvm/firecracker/pull/3086) via the `-m` flag. This should (hopefully) make the pipeline a little less flaky if this is indeed the reason for the command to seemingly randomly fail.

It's worth nothing that if this is the real issue (which it seems to not be), this means we can remove the pipeline concurrency group. I think I shared some info with the team as to what behaviors are shown before the loop device setup fails (specifically, when creating the working directory in the first pipeline step, the ones that fail to setup the loop device seem to have a different setup process than the ones that pass), so maybe a deeper dive into that would help fix pipeline flakiness. Still, this is nice to have.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
