### PR TITLE
Remove io/ioutil since it has been deprecated

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -16,7 +16,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,7 +29,7 @@ import (
 const numberOfVMs = 200
 
 func createMachine(ctx context.Context, name string, forwardSignals []os.Signal) (*Machine, func(), error) {
-	dir, err := ioutil.TempDir("", name)
+	dir, err := os.MkdirTemp("", name)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/examples/cmd/snapshotting/example_demo.go
+++ b/examples/cmd/snapshotting/example_demo.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -45,7 +44,7 @@ const (
 )
 
 func writeCNIConfWithHostLocalSubnet(path, networkName, subnet string) error {
-	return ioutil.WriteFile(path, []byte(fmt.Sprintf(`{
+	return os.WriteFile(path, []byte(fmt.Sprintf(`{
 		"cniVersion": "0.3.1",
 		"name": "%s",
 		"plugins": [
@@ -113,7 +112,7 @@ func createNewConfig(socketPath string, opts ...configOpt) sdk.Config {
 }
 
 func connectToVM(m *sdk.Machine, sshKeyPath string) (*ssh.Client, error) {
-	key, err := ioutil.ReadFile(sshKeyPath)
+	key, err := os.ReadFile(sshKeyPath)
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +406,7 @@ func main() {
 	defer os.Remove(cniConfDir)
 
 	// Setup socket and snapshot + memory paths
-	tempdir, err := ioutil.TempDir("", "FCGoSDKSnapshotExample")
+	tempdir, err := os.MkdirTemp("", "FCGoSDKSnapshotExample")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/jailer.go
+++ b/jailer.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -124,7 +123,7 @@ func NewJailerCommandBuilder() JailerCommandBuilder {
 
 // getNumaCpuset returns the CPU list assigned to a NUMA node
 func getNumaCpuset(node int) string {
-	if cpus, err := ioutil.ReadFile(fmt.Sprintf("/sys/devices/system/node/node%d/cpulist", node)); err == nil {
+	if cpus, err := os.ReadFile(fmt.Sprintf("/sys/devices/system/node/node%d/cpulist", node)); err == nil {
 		return strings.TrimSuffix(string(cpus), "\n")
 	}
 	return ""

--- a/machine_test.go
+++ b/machine_test.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -92,9 +91,7 @@ var fsSafeTestName = strings.NewReplacer("/", "_")
 func makeSocketPath(tb testing.TB) (string, func()) {
 	tb.Helper()
 
-	dir, err := ioutil.TempDir("", fsSafeTestName.Replace(tb.Name()))
-	require.NoError(tb, err)
-
+	dir := tb.TempDir()
 	return filepath.Join(dir, "fc.sock"), func() { os.RemoveAll(dir) }
 }
 
@@ -155,7 +152,7 @@ func TestJailerMicroVMExecution(t *testing.T) {
 
 	// uses temp directory due to testdata's path being too long which causes a
 	// SUN_LEN error.
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "jailer-test")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "jailer-test")
 	if err != nil {
 		t.Fatalf("Failed to create temporary directory: %v", err)
 	}
@@ -298,10 +295,7 @@ func TestMicroVMExecution(t *testing.T) {
 	cpuTemplate := models.CPUTemplate(models.CPUTemplateT2)
 	var memSz int64 = 256
 
-	dir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	socketPath := filepath.Join(dir, "TestMicroVMExecution.sock")
 	logFifo := filepath.Join(dir, "firecracker.log")
 	metricsFifo := filepath.Join(dir, "firecracker-metrics")
@@ -485,9 +479,7 @@ func TestLogAndMetrics(t *testing.T) {
 func testLogAndMetrics(t *testing.T, logLevel string) string {
 	const vmID = "UserSuppliedVMID"
 
-	dir, err := ioutil.TempDir("", strings.Replace(t.Name(), "/", "_", -1))
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	socketPath := filepath.Join(dir, "fc.sock")
 
@@ -536,7 +528,7 @@ func testLogAndMetrics(t *testing.T, logLevel string) string {
 	require.NoError(t, err)
 	assert.NotEqual(t, 0, log.Size())
 
-	content, err := ioutil.ReadFile(cfg.LogPath)
+	content, err := os.ReadFile(cfg.LogPath)
 	require.NoError(t, err)
 	return string(content)
 }
@@ -1000,9 +992,7 @@ func TestLogFiles(t *testing.T) {
 }
 
 func TestCaptureFifoToFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	fifoPath := filepath.Join(dir, "TestCaptureFifoToFile")
 
@@ -1051,15 +1041,13 @@ func TestCaptureFifoToFile(t *testing.T) {
 	wg.Wait()
 	_, err = os.Stat(logPath)
 	assert.NoError(t, err, "failed to stat file")
-	b, err := ioutil.ReadFile(logPath)
+	b, err := os.ReadFile(logPath)
 	assert.NoError(t, err, "failed to read logPath")
 	assert.Equal(t, expectedBytes, b)
 }
 
 func TestCaptureFifoToFile_nonblock(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	fifoPath := filepath.Join(dir, "TestCaptureFifoToFile_nonblock")
 
@@ -1114,7 +1102,7 @@ func TestCaptureFifoToFile_nonblock(t *testing.T) {
 	wg.Wait()
 	_, err = os.Stat(logPath)
 	assert.NoError(t, err, "failed to stat file")
-	b, err := ioutil.ReadFile(logPath)
+	b, err := os.ReadFile(logPath)
 	assert.NoError(t, err, "failed to read logPath")
 	assert.Equal(t, expectedBytes, b)
 }
@@ -1179,9 +1167,7 @@ func TestPID(t *testing.T) {
 		t.Errorf("expected an error, but received none")
 	}
 
-	dir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	var nCpus int64 = 2
 	cpuTemplate := models.CPUTemplate(models.CPUTemplateT2)
@@ -1191,10 +1177,10 @@ func TestPID(t *testing.T) {
 
 	vmlinuxPath := getVmlinuxPath(t)
 
-	rootfsBytes, err := ioutil.ReadFile(testRootfs)
+	rootfsBytes, err := os.ReadFile(testRootfs)
 	require.NoError(t, err, "failed to read rootfs file")
 	rootfsPath := filepath.Join(dir, "TestPID.img")
-	err = ioutil.WriteFile(rootfsPath, rootfsBytes, 0666)
+	err = os.WriteFile(rootfsPath, rootfsBytes, 0666)
 	require.NoError(t, err, "failed to copy vm rootfs to %s", rootfsPath)
 
 	cfg := Config{
@@ -1260,12 +1246,10 @@ func TestCaptureFifoToFile_leak(t *testing.T) {
 		exitCh: make(chan struct{}),
 	}
 
-	dir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	fifoPath := filepath.Join(dir, "TestCaptureFifoToFileLeak.fifo")
-	err = syscall.Mkfifo(fifoPath, 0700)
+	err := syscall.Mkfifo(fifoPath, 0700)
 	require.NoError(t, err, "failed to make fifo")
 	defer os.Remove(fifoPath)
 
@@ -1646,10 +1630,6 @@ func TestPauseResume(t *testing.T) {
 	fctesting.RequiresKVM(t)
 	fctesting.RequiresRoot(t)
 
-	dir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
 	cases := []struct {
 		name  string
 		state func(m *Machine, ctx context.Context)
@@ -1758,9 +1738,7 @@ func TestCreateSnapshot(t *testing.T) {
 	fctesting.RequiresKVM(t)
 	fctesting.RequiresRoot(t)
 
-	dir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cases := []struct {
 		name           string
@@ -1822,7 +1800,7 @@ func TestCreateSnapshot(t *testing.T) {
 }
 
 func connectToVM(m *Machine, sshKeyPath string) (*ssh.Client, error) {
-	key, err := ioutil.ReadFile(sshKeyPath)
+	key, err := os.ReadFile(sshKeyPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1851,7 +1829,7 @@ func connectToVM(m *Machine, sshKeyPath string) (*ssh.Client, error) {
 }
 
 func writeCNIConfWithHostLocalSubnet(path, networkName, subnet string) error {
-	return ioutil.WriteFile(path, []byte(fmt.Sprintf(`{
+	return os.WriteFile(path, []byte(fmt.Sprintf(`{
 		"cniVersion": "0.3.1",
 		"name": "%s",
 		"plugins": [
@@ -1873,26 +1851,24 @@ func TestLoadSnapshot(t *testing.T) {
 	fctesting.RequiresKVM(t)
 	fctesting.RequiresRoot(t)
 
-	dir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cniConfDir := filepath.Join(dir, "cni.conf")
-	err = os.MkdirAll(cniConfDir, 0777)
+	err := os.MkdirAll(cniConfDir, 0777)
 	require.NoError(t, err)
 
 	cniBinPath := []string{testDataBin}
 
-	rootfsBytes, err := ioutil.ReadFile(testRootfsWithSSH)
+	rootfsBytes, err := os.ReadFile(testRootfsWithSSH)
 	require.NoError(t, err)
 	rootfsPath := filepath.Join(dir, "rootfs.img")
-	err = ioutil.WriteFile(rootfsPath, rootfsBytes, 0666)
+	err = os.WriteFile(rootfsPath, rootfsBytes, 0666)
 	require.NoError(t, err)
 
-	sshKeyBytes, err := ioutil.ReadFile(testSSHKey)
+	sshKeyBytes, err := os.ReadFile(testSSHKey)
 	require.NoError(t, err)
 	sshKeyPath := filepath.Join(dir, "id_rsa")
-	err = ioutil.WriteFile(sshKeyPath, sshKeyBytes, 0600)
+	err = os.WriteFile(sshKeyPath, sshKeyBytes, 0600)
 	require.NoError(t, err)
 
 	// Using default cache directory to ensure collision avoidance on IP allocations

--- a/network_test.go
+++ b/network_test.go
@@ -16,7 +16,6 @@ package firecracker
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -255,9 +254,7 @@ func testNetworkMachineCNI(t *testing.T, useConfFile bool) {
 
 	cniBinPath := []string{"/opt/cni/bin", testDataBin}
 
-	dir, err := ioutil.TempDir("", fsSafeTestName.Replace(t.Name()))
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	testCNIDir := filepath.Join(dir, "TestCNI")
 	os.RemoveAll(testCNIDir)
@@ -299,7 +296,7 @@ func testNetworkMachineCNI(t *testing.T, useConfFile bool) {
 	cniConfPath := filepath.Join(cniConfDir, fmt.Sprintf("%s.conflist", networkName))
 	if useConfFile {
 		require.NoError(t,
-			ioutil.WriteFile(cniConfPath, []byte(cniConf), 0666), // broad permissions for tests
+			os.WriteFile(cniConfPath, []byte(cniConf), 0666), // broad permissions for tests
 			"failed to write cni conf file")
 	} else {
 		// make sure config file doesn't exist
@@ -385,9 +382,9 @@ func newCNIMachine(t *testing.T,
 	cniBinPath []string,
 	networkConf *libcni.NetworkConfigList,
 ) *Machine {
-	rootfsBytes, err := ioutil.ReadFile(testRootfs)
+	rootfsBytes, err := os.ReadFile(testRootfs)
 	require.NoError(t, err, "failed to read rootfs file")
-	err = ioutil.WriteFile(rootfsPath, rootfsBytes, 0666)
+	err = os.WriteFile(rootfsPath, rootfsBytes, 0666)
 	require.NoError(t, err, "failed to copy vm rootfs to %s", rootfsPath)
 
 	if networkConf != nil {

--- a/vsock/dial.go
+++ b/vsock/dial.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"strings"
 	"time"
@@ -37,7 +37,7 @@ type config struct {
 
 func defaultConfig() config {
 	noop := logrus.New()
-	noop.Out = ioutil.Discard
+	noop.Out = io.Discard
 
 	return config{
 		DialTimeout:       100 * time.Millisecond,


### PR DESCRIPTION
The package has been deprecated since 1.16.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
