### PR TITLE
Removing CPUTemplate field from the example code in fc-go-sdk

### DIFF
--- a/examples/cmd/snapshotting/example_demo.go
+++ b/examples/cmd/snapshotting/example_demo.go
@@ -77,7 +77,6 @@ func createNewConfig(socketPath string, opts ...configOpt) sdk.Config {
 	kernelImagePath := filepath.Join(dir, "vmlinux")
 
 	var vcpuCount int64 = 2
-	cpuTemplate := models.CPUTemplate(models.CPUTemplateT2)
 	var memSizeMib int64 = 256
 	smt := false
 
@@ -91,7 +90,6 @@ func createNewConfig(socketPath string, opts ...configOpt) sdk.Config {
 		KernelImagePath: kernelImagePath,
 		MachineCfg: models.MachineConfiguration{
 			VcpuCount:   &vcpuCount,
-			CPUTemplate: cpuTemplate,
 			MemSizeMib:  &memSizeMib,
 			Smt:         &smt,
 		},


### PR DESCRIPTION
Signed-off-by: Vaishnavi Vejella <vvejella@amazon.com>

*Issue:* CPU Template defines a set of flags to be disabled from the microvm by that the features get exposed to the guest are the same as in the selected instance type and this works only on Intel not for the AMD. 
*Description of changes:* Removed references of CPUTemplate in order to pass tests against AMD in BuildKite.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
