### PR TITLE
Update GHA runner images

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         go: ['1.14', '1.15', '1.16', '1.17', '1.18', '1.19']
-        os: ['ubuntu-18.04', 'ubuntu-20.04']
+        os: ['ubuntu-22.04']
       fail-fast: false
     name: ${{ matrix.os }} / Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:*
n/a

*Description of changes:*
Updating GHA OS matrix to use the latest Ubuntu image available.

* Removed 18.04 marked for deprecation
* Updated 20.04 to 22.04 which both use the same Linux kernel so no reason to have both.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
