### PR TITLE
Chore: Bump GH actions versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Test
       run: make test EXTRAGOARGS=-v


### PR DESCRIPTION
*Issue #, if available:* #463

*Description of changes:*
To get rid of the actions warnings because of Node 12 deprecations this will bump the actions to use Node 16 by default. This closes #463. 

I tested it locally with running [act](https://github.com/nektos/act). If there is another way to do so please let me know.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
