### PR TITLE
Specify Cgroups versions for JailerConfig

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -233,6 +233,7 @@ func TestJailerMicroVMExecution(t *testing.T) {
 			ChrootStrategy: NewNaiveChrootStrategy(vmlinuxPath),
 			Stdout:         logFd,
 			Stderr:         logFd,
+			CgroupVersion:  "2",
 		},
 		FifoLogWriter: fw,
 	}


### PR DESCRIPTION
Signed-off-by: Vaishnavi Vejella <vvejella@amazon.com>

*Issue #467:*
**TestJailerMicroVMExecution** is failed to start VMM and Firecracker was not able to create an API socket due to CgroupsVersion field on the JailerConfig is not specified, thus the default is using v1 with the jailer binary.

*Description of changes:*
Modified the Jailer Config by specifying cgroups as v2 in TestJailerMicroVMExecution to` CgroupVersion: "2"`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
