### PR TITLE
Reduce sudo

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -78,7 +78,7 @@ steps:
       - make deps
       # Build a rootfs with SSH enabled.
       - sudo -E FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH} make ${FC_TEST_DATA_PATH}/root-drive-ssh-key
-      - stat ${FC_TEST_DATA_PATH}/root-drive-ssh-key ${FC_TEST_DATA_PATH}/root-drive-with-ssh.img
+      - sudo chown $USER ${FC_TEST_DATA_PATH}/root-drive-ssh-key ${FC_TEST_DATA_PATH}/root-drive-with-ssh.img
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
@@ -103,8 +103,11 @@ steps:
   
   - label: ':book: examples'
     commands:
-      - "sudo -E PATH=$PATH FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH} make -C examples/cmd/snapshotting run"
-      - "sudo -E PATH=$PATH FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH} make -C examples/cmd/snapshotting clean"
+      - cp ${FC_TEST_DATA_PATH}/root-drive-ssh-key ${FC_TEST_DATA_PATH}/root-drive-with-ssh.img ${FC_TEST_DATA_PATH}/vmlinux examples/cmd/snapshotting
+      - cd examples/cmd/snapshotting
+      - make all
+      - export FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH}
+      - sudo -E make run clean
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
@@ -120,7 +123,9 @@ steps:
 
   - label: ':hammer: root tests'
     commands:
-      - "sudo -E PATH=$PATH FC_TEST_TAP=fc-root-tap${BUILDKITE_BUILD_NUMBER} FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS="
+      - export FC_TEST_TAP=fc-root-tap${BUILDKITE_BUILD_NUMBER}
+      - export FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH}
+      - make test EXTRAGOARGS="-exec 'sudo -E' -count=1 -race" DISABLE_ROOT_TESTS=
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
@@ -132,7 +137,8 @@ steps:
       FC_TEST_JAILER_BIN: "${FC_TEST_DATA_PATH}/jailer-main"
       DOCKER_IMAGE_TAG: "$BUILDKITE_BUILD_NUMBER"
     commands:
-      - "sudo -E PATH=$PATH FC_TEST_TAP=fc-mst-tap${BUILDKITE_BUILD_NUMBER} make test EXTRAGOARGS='-v -count=1 -race' DISABLE_ROOT_TESTS="
+      - export FC_TEST_TAP=fc-mst-tap${BUILDKITE_BUILD_NUMBER}
+      - make test EXTRAGOARGS="-exec 'sudo -E' -v -count=1 -race" DISABLE_ROOT_TESTS=
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,11 +65,6 @@ steps:
   - wait
 
   - label: ':package: install'
-    # This concurrency group can be removed when one of the below issues are resolved:
-    # https://github.com/firecracker-microvm/firecracker-go-sdk/issues/418
-    # https://github.com/firecracker-microvm/firecracker/issues/3058
-    concurrency_group: "mount rootfs"
-    concurrency: 1
     env:
       GOBIN: "$FC_TEST_DATA_PATH/bin"
     commands:

--- a/examples/cmd/snapshotting/Makefile
+++ b/examples/cmd/snapshotting/Makefile
@@ -33,7 +33,7 @@ else
     endef
 endif
 
-all: plugins image vmlinux firecracker
+all: snapshot-example plugins root-drive-with-ssh.img root-drive-ssh-key vmlinux firecracker
 
 plugins: bin/tc-redirect-tap bin/ptp bin/host-local | bin
 
@@ -48,15 +48,6 @@ bin/ptp: bin
 
 bin/host-local: bin
 	$(call install_go,github.com/containernetworking/plugins/plugins/ipam/host-local,v1.1.1)
-	
-image:
-ifeq ($(GID), 0)
-	- cp ${FC_TEST_DATA_PATH}/root-drive-with-ssh.img root-drive-with-ssh.img
-	- cp ${FC_TEST_DATA_PATH}/root-drive-ssh-key root-drive-ssh-key
-	$(MAKE) root-drive-with-ssh.img root-drive-ssh-key
-else
-	$(error unable to place ssh key without root permissions)
-endif
 
 vmlinux:
 	curl --location -o vmlinux https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/${ARCH}/kernels/vmlinux.bin
@@ -74,10 +65,13 @@ root-drive-with-ssh.img root-drive-ssh-key:
 	cp temp/build/rootfs/ssh/id_rsa root-drive-ssh-key
 	rm -rf temp
 
-run: all
-	go run example_demo.go
+snapshot-example:
+	go build -o $@
+
+run: snapshot-example
+	./snapshot-example
 
 clean:
 	rm -rf bin firecracker root-drive-ssh-key root-drive-with-ssh.img vmlinux
 
-.PHONY: all clean image plugins run
+.PHONY: all clean plugins run


### PR DESCRIPTION
We are using sudo too much. While there are operations that only root can do (chown, mount, ...), go and make don't need root.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
