### PR TITLE
Set cniBinPath to testDataBin

### DIFF
--- a/network_test.go
+++ b/network_test.go
@@ -253,7 +253,7 @@ func testNetworkMachineCNI(t *testing.T, useConfFile bool) {
 	}
 	fctesting.RequiresRoot(t)
 
-	cniBinPath := []string{"/opt/cni/bin", testDataBin}
+	cniBinPath := []string{testDataBin}
 
 	dir, err := ioutil.TempDir("", fsSafeTestName.Replace(t.Name()))
 	require.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Vaishnavi Vejella <vvejella@amazon.com>

*Issue :*
The CNI plugins are included in **testdata_objects**, which is a dependency of the Makefile test rule, So to install CNI plugins  to **testDataBin** regardless of platform.
*Description of changes:*
Specified the `cniBinPath := []string{testDataBin}`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
