### PR TITLE
Run tests against Firecracker's released version even test-images fails

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,19 +42,6 @@ steps:
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
 
-  # Since make test-images mutates the source directory, it cannot be run with other steps.
-  - wait
-
-  - label: ':linux: build docker images'
-    commands:
-      - make test-images
-    agents:
-      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
-      distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
-      hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
-
-  - wait
-
   - label: 'git log validation'
     command: './.buildkite/logcheck.sh'
     # This should run in the same queue, but we don't care whether it runs on
@@ -131,7 +118,28 @@ steps:
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
       hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
 
-  - label: ':hammer: test against firecracker main'
+  - label: 'go mod tidy'
+    commands:
+      - 'go mod tidy'
+      - test -z "$(git status --porcelain)" && exit 0 || git --no-pager diff && echo -e '\ngo.mod and/or go.sum differ from committed, please run "go mod tidy" and commit the updated files.\n' && exit 1
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
+      distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
+      hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
+
+  - wait
+
+  - label: ':linux: build Firecracker from the tip of main branch'
+    commands:
+      - make test-images
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
+      distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
+      hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
+
+  - wait
+
+  - label: ':hammer: test against Firecracker above'
     env:
       FC_TEST_BIN: "${FC_TEST_DATA_PATH}/firecracker-main"
       FC_TEST_JAILER_BIN: "${FC_TEST_DATA_PATH}/jailer-main"
@@ -139,15 +147,6 @@ steps:
     commands:
       - export FC_TEST_TAP=fc-mst-tap${BUILDKITE_BUILD_NUMBER}
       - make test EXTRAGOARGS="-exec 'sudo -E' -v -count=1 -race" DISABLE_ROOT_TESTS=
-    agents:
-      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
-      distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
-      hostname: "${BUILDKITE_AGENT_META_DATA_HOSTNAME}"
-
-  - label: 'go mod tidy'
-    commands:
-      - 'go mod tidy'
-      - test -z "$(git status --porcelain)" && exit 0 || git --no-pager diff && echo -e '\ngo.mod and/or go.sum differ from committed, please run "go mod tidy" and commit the updated files.\n' && exit 1
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"

--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,7 @@ $(FIRECRACKER_DIR):
 test-images: $(FIRECRACKER_BIN) $(JAILER_BIN)
 
 $(FIRECRACKER_BIN) $(JAILER_BIN): $(FIRECRACKER_DIR)
-	$(FIRECRACKER_DIR)/tools/devtool -y build --release && \
-		$(FIRECRACKER_DIR)/tools/devtool strip
+	$(FIRECRACKER_DIR)/tools/devtool -y build --release
 	cp $(FIRECRACKER_DIR)/build/cargo_target/$(FIRECRACKER_TARGET)/release/firecracker $(FIRECRACKER_BIN)
 	cp $(FIRECRACKER_DIR)/build/cargo_target/$(FIRECRACKER_TARGET)/release/jailer $(JAILER_BIN)
 


### PR DESCRIPTION
Firecracker's main branch cannot be built, probably due to https://github.com/firecracker-microvm/firecracker/pull/3361.

However this should not prevent running tests against Firecracker's released version we already have in the BuildKite hosts.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
