### PR TITLE
Fix CI build by using pre-built rootfs image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,11 +61,9 @@ steps:
       # Copy vmlinux and root-drive.img.
       - ln -s /var/lib/fc-ci/vmlinux.bin ${FC_TEST_DATA_PATH}/vmlinux
       - ln -s /var/lib/fc-ci/rootfs.ext4 ${FC_TEST_DATA_PATH}/root-drive.img
-      # Download Firecracker and its jailer.
-      - make deps
-      # Build a rootfs with SSH enabled.
-      - sudo -E FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH} make ${FC_TEST_DATA_PATH}/root-drive-ssh-key
-      - sudo chown $USER ${FC_TEST_DATA_PATH}/root-drive-ssh-key ${FC_TEST_DATA_PATH}/root-drive-with-ssh.img
+      # Download Firecracker and its jailer
+      # Download pre-built rootfs with SSH enabled and its ssh key.
+      - make deps  
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"
@@ -90,6 +88,7 @@ steps:
   
   - label: ':book: examples'
     commands:
+      # Copy those deps from install step to save time re-downloading
       - cp ${FC_TEST_DATA_PATH}/root-drive-ssh-key ${FC_TEST_DATA_PATH}/root-drive-with-ssh.img ${FC_TEST_DATA_PATH}/vmlinux examples/cmd/snapshotting
       - cd examples/cmd/snapshotting
       - make all
@@ -112,7 +111,7 @@ steps:
     commands:
       - export FC_TEST_TAP=fc-root-tap${BUILDKITE_BUILD_NUMBER}
       - export FC_TEST_DATA_PATH=${FC_TEST_DATA_PATH}
-      - make test EXTRAGOARGS="-exec 'sudo -E' -count=1 -race" DISABLE_ROOT_TESTS=
+      - make test EXTRAGOARGS="-exec 'sudo -E' -v -count=1 -race" DISABLE_ROOT_TESTS=
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE:-default}"
       distro: "${BUILDKITE_AGENT_META_DATA_DISTRO}"

--- a/examples/cmd/snapshotting/Makefile
+++ b/examples/cmd/snapshotting/Makefile
@@ -21,6 +21,9 @@ PWD=$(shell pwd)
 GOBIN=$(PWD)/bin
 FC_TEST_DATA_PATH?=$(PWD)
 
+# --location is needed to follow redirects on github.com
+curl = curl --location
+
 GO_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1,2)
 ifeq ($(GO_VERSION), $(filter $(GO_VERSION),1.14 1.15))
     define install_go
@@ -50,21 +53,22 @@ bin/host-local: bin
 	$(call install_go,github.com/containernetworking/plugins/plugins/ipam/host-local,v1.1.1)
 
 vmlinux:
-	curl --location -o vmlinux https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/${ARCH}/kernels/vmlinux.bin
+	$(curl) -o vmlinux https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/${ARCH}/kernels/vmlinux.bin
 
 firecracker:
-	curl -L ${RELEASE_URL}/download/${VER}/firecracker-${VER}-${ARCH}.tgz | tar -xz
+	$(curl) ${RELEASE_URL}/download/${VER}/firecracker-${VER}-${ARCH}.tgz | tar -xz
 	mv release-${VER}-${ARCH}/firecracker-${VER}-${ARCH} firecracker
 	rm -rf release-${VER}-${ARCH}
 
+# Use rootfs and ssh key pre-built from S3 following firecracker getting-started guide
+# https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md
+# TODO: Change the pre-built rootfs to ubuntu 22.04 once firecracker team has that in the public S3 bucket
+# Currently the S3 bucket only has ubuntu 18.04 image
 root-drive-with-ssh.img root-drive-ssh-key:
-	- mkdir temp
-	- git clone https://github.com/firecracker-microvm/firecracker temp
-	temp/tools/devtool build_rootfs
-	cp temp/build/rootfs/bionic.rootfs.ext4 root-drive-with-ssh.img
-	cp temp/build/rootfs/ssh/id_rsa root-drive-ssh-key
-	rm -rf temp
-
+	$(curl) -o root-drive-with-ssh.img https://s3.amazonaws.com/spec.ccfc.min/ci-artifacts/disks/${ARCH}/ubuntu-18.04.ext4
+	$(curl) -o root-drive-ssh-key https://s3.amazonaws.com/spec.ccfc.min/ci-artifacts/disks/${ARCH}/ubuntu-18.04.id_rsa
+	
+	
 snapshot-example:
 	go build -o $@
 
@@ -72,6 +76,6 @@ run: snapshot-example
 	./snapshot-example
 
 clean:
-	rm -rf bin firecracker root-drive-ssh-key root-drive-with-ssh.img vmlinux
+	rm -rf bin firecracker root-drive-ssh-key root-drive-with-ssh.img snapshot-example vmlinux  
 
 .PHONY: all clean plugins run

--- a/examples/cmd/snapshotting/README.md
+++ b/examples/cmd/snapshotting/README.md
@@ -9,7 +9,7 @@ This test requires both KVM and root access.
 Run this test by first running
 
 ```
-sudo -E env PATH=$PATH make all
+make all
 ```
 
 followed by
@@ -18,7 +18,7 @@ followed by
 sudo -E env PATH=$PATH go run example_demo.go
 ```
 
-Alternatively, to do both of the above,
+or,
 ```
 sudo -E env PATH=$PATH make run
 ```
@@ -62,20 +62,5 @@ Pressing enter resumes execution of the program.
 You can remove dependencies via a simple `make clean`.
 
 ```
-sudo make clean
-```
-
-## Issues
-
-You may encounter an issue where the image does not build properly. This is often indicated via the following near the end of terminal output:
-
-```
-umount: /firecracker/build/rootfs/mnt: not mounted.
-```
-
-This is due to an issue in Firecracker's devtool command used to dynamically create an image. Fixing this is often as simple as rerunning the command.
-
-```
-sudo rm -rf root-drive-with-ssh.img root-drive-ssh-key
-sudo make image
+make clean
 ```

--- a/examples/cmd/snapshotting/example_demo.go
+++ b/examples/cmd/snapshotting/example_demo.go
@@ -89,9 +89,9 @@ func createNewConfig(socketPath string, opts ...configOpt) sdk.Config {
 		SocketPath:      socketPath,
 		KernelImagePath: kernelImagePath,
 		MachineCfg: models.MachineConfiguration{
-			VcpuCount:   &vcpuCount,
-			MemSizeMib:  &memSizeMib,
-			Smt:         &smt,
+			VcpuCount:  &vcpuCount,
+			MemSizeMib: &memSizeMib,
+			Smt:        &smt,
 		},
 		Drives: []models.Drive{
 			{
@@ -412,13 +412,15 @@ func main() {
 	defer os.Remove(tempdir)
 	socketPath := filepath.Join(tempdir, "snapshotssh")
 
-	err = os.Mkdir("snapshotssh", 0777)
+	snapshotsshPath := filepath.Join(dir, "snapshotssh")
+	err = os.Mkdir(snapshotsshPath, 0777)
 	if err != nil && !errors.Is(err, os.ErrExist) {
 		log.Fatal(err)
 	}
+	defer os.RemoveAll(snapshotsshPath)
 
-	snapPath := filepath.Join(dir, "snapshotssh/SnapFile")
-	memPath := filepath.Join(dir, "snapshotssh/MemFile")
+	snapPath := filepath.Join(snapshotsshPath, "SnapFile")
+	memPath := filepath.Join(snapshotsshPath, "MemFile")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
*Issue #, if available:*
#418 
The main branch is failing due to hardcoded rootfs name as the name changed with upstream firecracker moving from bionic to jammy.  Also devtool used to build rootfs is unstable. 
```
cp: cannot stat 'build/firecracker/build/rootfs/bionic.rootfs.ext4': No such file or directory
```

*Description of changes:*
1. Not specify the ubuntu version name but using regex to match it. The approach is safe since we will only have one rootfs built at a time.
2. Use prebuilt rootfs and ssh key from S3 instead of building from devtool on fly which seems pretty unstable.
3.  Update readme of snapshotting example to reflect current status. 
4.  Minor update for the snapshotting example code to clean up generated files. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Signed-off-by: Tony Fang <nhfang@amazon.com>