### PR TITLE
Remove `addVsocksHandler` from `loadSnapshotHandlerList`

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -321,7 +321,6 @@ var loadSnapshotHandlerList = HandlerList{}.Append(
 	CreateLogFilesHandler,
 	BootstrapLoggingHandler,
 	LoadSnapshotHandler,
-	AddVsocksHandler,
 )
 
 var defaultValidationHandlerList = HandlerList{}.Append(


### PR DESCRIPTION
*Issue #, if available: #506*

*Description of changes:*
According to the firecracker OpenAPI specification[^1], creating vsock devices is only a pre-boot request, so adding vsocks after loading a snapshot fails. It also seems redundant, since the VM loaded from a snapshot restores vsocks anyways.

Closes #506

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[^1]: https://github.com/firecracker-microvm/firecracker/blob/56aeeac51c00b449a45be4542b3e807d34690ba7/src/api_server/swagger/firecracker.yaml#L676-L678
