### PR TITLE
chore: Replaced deprecated methods in ioutil using io and os packages

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -16,7 +16,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,13 +23,13 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
+	"github.com/firecracker-microvm/firecracker-go-sdk/client/models"
 )
 
 const numberOfVMs = 200
 
 func createMachine(ctx context.Context, name string, forwardSignals []os.Signal) (*Machine, func(), error) {
-	dir, err := ioutil.TempDir("", name)
+	dir, err := os.MkdirTemp("", name)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -50,9 +49,9 @@ func createMachine(ctx context.Context, name string, forwardSignals []os.Signal)
 		MetricsFifo:     metrics,
 		LogLevel:        "Info",
 		MachineCfg: models.MachineConfiguration{
-			VcpuCount:   Int64(1),
-			MemSizeMib:  Int64(256),
-			Smt:         Bool(false),
+			VcpuCount:  Int64(1),
+			MemSizeMib: Int64(256),
+			Smt:        Bool(false),
 		},
 		Drives: []models.Drive{
 			{

--- a/examples/cmd/snapshotting/example_demo.go
+++ b/examples/cmd/snapshotting/example_demo.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -45,7 +44,7 @@ const (
 )
 
 func writeCNIConfWithHostLocalSubnet(path, networkName, subnet string) error {
-	return ioutil.WriteFile(path, []byte(fmt.Sprintf(`{
+	return os.WriteFile(path, []byte(fmt.Sprintf(`{
 		"cniVersion": "0.3.1",
 		"name": "%s",
 		"plugins": [
@@ -60,7 +59,7 @@ func writeCNIConfWithHostLocalSubnet(path, networkName, subnet string) error {
 			"type": "tc-redirect-tap"
 		  }
 		]
-	  }`, networkName, subnet)), 0644)
+	 }`, networkName, subnet)), 0644)
 }
 
 type configOpt func(*sdk.Config)
@@ -111,7 +110,7 @@ func createNewConfig(socketPath string, opts ...configOpt) sdk.Config {
 }
 
 func connectToVM(m *sdk.Machine, sshKeyPath string) (*ssh.Client, error) {
-	key, err := ioutil.ReadFile(sshKeyPath)
+	key, err := os.ReadFile(sshKeyPath)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +404,7 @@ func main() {
 	defer os.Remove(cniConfDir)
 
 	// Setup socket and snapshot + memory paths
-	tempdir, err := ioutil.TempDir("", "FCGoSDKSnapshotExample")
+	tempdir, err := os.MkdirTemp("", "FCGoSDKSnapshotExample")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/jailer.go
+++ b/jailer.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -124,7 +123,7 @@ func NewJailerCommandBuilder() JailerCommandBuilder {
 
 // getNumaCpuset returns the CPU list assigned to a NUMA node
 func getNumaCpuset(node int) string {
-	if cpus, err := ioutil.ReadFile(fmt.Sprintf("/sys/devices/system/node/node%d/cpulist", node)); err == nil {
+	if cpus, err := os.ReadFile(fmt.Sprintf("/sys/devices/system/node/node%d/cpulist", node)); err == nil {
 		return strings.TrimSuffix(string(cpus), "\n")
 	}
 	return ""

--- a/network_test.go
+++ b/network_test.go
@@ -16,7 +16,6 @@ package firecracker
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -26,7 +25,7 @@ import (
 	"time"
 
 	"github.com/containernetworking/cni/libcni"
-	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
+	"github.com/firecracker-microvm/firecracker-go-sdk/client/models"
 	"github.com/firecracker-microvm/firecracker-go-sdk/fctesting"
 	"github.com/go-ping/ping"
 	"github.com/stretchr/testify/assert"
@@ -256,7 +255,7 @@ func testNetworkMachineCNI(t *testing.T, useConfFile bool) {
 
 	cniBinPath := []string{testDataBin, "/opt/cni/bin"}
 
-	dir, err := ioutil.TempDir("", fsSafeTestName.Replace(t.Name()))
+	dir, err := os.MkdirTemp("", fsSafeTestName.Replace(t.Name()))
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -300,7 +299,7 @@ func testNetworkMachineCNI(t *testing.T, useConfFile bool) {
 	cniConfPath := filepath.Join(cniConfDir, fmt.Sprintf("%s.conflist", networkName))
 	if useConfFile {
 		require.NoError(t,
-			ioutil.WriteFile(cniConfPath, []byte(cniConf), 0666), // broad permissions for tests
+			os.WriteFile(cniConfPath, []byte(cniConf), 0666), // broad permissions for tests
 			"failed to write cni conf file")
 	} else {
 		// make sure config file doesn't exist
@@ -389,9 +388,9 @@ func newCNIMachine(t *testing.T,
 	cniBinPath []string,
 	networkConf *libcni.NetworkConfigList,
 ) *Machine {
-	rootfsBytes, err := ioutil.ReadFile(testRootfs)
+	rootfsBytes, err := os.ReadFile(testRootfs)
 	require.NoError(t, err, "failed to read rootfs file")
-	err = ioutil.WriteFile(rootfsPath, rootfsBytes, 0666)
+	err = os.WriteFile(rootfsPath, rootfsBytes, 0666)
 	require.NoError(t, err, "failed to copy vm rootfs to %s", rootfsPath)
 
 	if networkConf != nil {

--- a/vsock/dial.go
+++ b/vsock/dial.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"strings"
 	"time"
@@ -37,7 +37,7 @@ type config struct {
 
 func defaultConfig() config {
 	noop := logrus.New()
-	noop.Out = ioutil.Discard
+	noop.Out = io.Discard
 
 	return config{
 		DialTimeout:       100 * time.Millisecond,


### PR DESCRIPTION
*Description of changes:*
The package has been deprecated since 1.16.

#440 
firecracker-go-sdk has dropped Go 1.14 and 1.15

Signed-off-by: NanamiNakano <thynanami@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
