### PR TITLE
Enable resuming snapshot for jailed firecracker

### DIFF
--- a/jailer.go
+++ b/jailer.go
@@ -430,7 +430,7 @@ func LinkFilesHandler(kernelImageFileName string) Handler {
 					"",
 				); err != nil {
 					return fmt.Errorf(
-						"Failed to bind mount %s to %s: %v",
+						"failed to bind mount %s to %s: %v",
 						hostPath,
 						rootfsPath,
 						err,

--- a/jailer.go
+++ b/jailer.go
@@ -426,6 +426,22 @@ func LinkFilesHandler(kernelImageFileName string) Handler {
 				m.Cfg.Drives[i].PathOnHost = String(driveFileName)
 			}
 
+			if err := os.Link(
+				m.Cfg.Snapshot.SnapshotPath,
+				filepath.Join(rootfs, filepath.Base(m.Cfg.Snapshot.SnapshotPath)),
+			); err != nil {
+				return err
+			}
+			m.Cfg.Snapshot.SnapshotPath = filepath.Base(m.Cfg.Snapshot.SnapshotPath)
+
+			if err := os.Link(
+				m.Cfg.Snapshot.GetMemBackendPath(),
+				filepath.Join(rootfs, filepath.Base(m.Cfg.Snapshot.MemFilePath)),
+			); err != nil {
+				return err
+			}
+			m.Cfg.Snapshot.MemFilePath = filepath.Base(m.Cfg.Snapshot.MemFilePath)
+
 			m.Cfg.KernelImagePath = kernelImageFileName
 			if m.Cfg.InitrdPath != "" {
 				m.Cfg.InitrdPath = initrdFilename

--- a/jailer.go
+++ b/jailer.go
@@ -415,7 +415,7 @@ func LinkFilesHandler(kernelImageFileName string) Handler {
 			// copy all drives to the root fs
 			for i, drive := range m.Cfg.Drives {
 				hostPath := StringValue(drive.PathOnHost)
-				driveFileName := filepath.Base(hostPath)
+				driveFileName := "rootfs"
 				rootfsPath := filepath.Join(rootfs, driveFileName)
 
 				if _, err := os.OpenFile(rootfsPath, os.O_RDONLY|os.O_CREATE, 0000); err != nil {

--- a/jailer.go
+++ b/jailer.go
@@ -426,21 +426,23 @@ func LinkFilesHandler(kernelImageFileName string) Handler {
 				m.Cfg.Drives[i].PathOnHost = String(driveFileName)
 			}
 
-			if err := os.Link(
-				m.Cfg.Snapshot.SnapshotPath,
-				filepath.Join(rootfs, filepath.Base(m.Cfg.Snapshot.SnapshotPath)),
-			); err != nil {
-				return err
-			}
-			m.Cfg.Snapshot.SnapshotPath = filepath.Base(m.Cfg.Snapshot.SnapshotPath)
+			if m.Cfg.hasSnapshot() {
+				if err := os.Link(
+					m.Cfg.Snapshot.SnapshotPath,
+					filepath.Join(rootfs, filepath.Base(m.Cfg.Snapshot.SnapshotPath)),
+				); err != nil {
+					return err
+				}
+				m.Cfg.Snapshot.SnapshotPath = filepath.Base(m.Cfg.Snapshot.SnapshotPath)
 
-			if err := os.Link(
-				m.Cfg.Snapshot.GetMemBackendPath(),
-				filepath.Join(rootfs, filepath.Base(m.Cfg.Snapshot.MemFilePath)),
-			); err != nil {
-				return err
+				if err := os.Link(
+					m.Cfg.Snapshot.GetMemBackendPath(),
+					filepath.Join(rootfs, filepath.Base(m.Cfg.Snapshot.MemFilePath)),
+				); err != nil {
+					return err
+				}
+				m.Cfg.Snapshot.MemFilePath = filepath.Base(m.Cfg.Snapshot.MemFilePath)
 			}
-			m.Cfg.Snapshot.MemFilePath = filepath.Base(m.Cfg.Snapshot.MemFilePath)
 
 			m.Cfg.KernelImagePath = kernelImageFileName
 			if m.Cfg.InitrdPath != "" {

--- a/jailer.go
+++ b/jailer.go
@@ -393,9 +393,12 @@ func LinkFilesHandler(kernelImageFileName string) Handler {
 			)
 
 			// copy kernel image to root fs
-			if err := os.Link(
+			if err := unix.Mount(
 				m.Cfg.KernelImagePath,
 				filepath.Join(rootfs, kernelImageFileName),
+				"bind",
+				unix.MS_BIND,
+				"",
 			); err != nil {
 				return err
 			}

--- a/jailer.go
+++ b/jailer.go
@@ -419,7 +419,7 @@ func LinkFilesHandler(kernelImageFileName string) Handler {
 				rootfsPath := filepath.Join(rootfs, driveFileName)
 
 				if _, err := os.OpenFile(rootfsPath, os.O_RDONLY|os.O_CREATE, 0000); err != nil {
-					return fmt.Errorf("Failed to create directory %s: %v", rootfsPath, err)
+					return fmt.Errorf("failed to create directory %s: %v", rootfsPath, err)
 				}
 
 				if err := unix.Mount(

--- a/machine.go
+++ b/machine.go
@@ -236,10 +236,12 @@ func (cfg *Config) ValidateLoadSnapshot() error {
 	}
 
 	if _, err := os.Stat(cfg.Snapshot.GetMemBackendPath()); err != nil {
+		return fmt.Errorf("failed to stat mem backend path, %q: %v", cfg.Snapshot.GetMemBackendPath(), err)
 		return err
 	}
 
 	if _, err := os.Stat(cfg.Snapshot.SnapshotPath); err != nil {
+		return fmt.Errorf("failed to stat snapshot path, %q: %v", cfg.Snapshot.SnapshotPath, err)
 		return err
 	}
 

--- a/machine.go
+++ b/machine.go
@@ -35,6 +35,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
+	"golang.org/x/sys/unix"
 
 	log "github.com/sirupsen/logrus"
 
@@ -463,10 +464,29 @@ func (m *Machine) Start(ctx context.Context) error {
 func (m *Machine) Shutdown(ctx context.Context) error {
 	m.logger.Debug("Called machine.Shutdown()")
 	if runtime.GOARCH != "arm64" {
-		return m.sendCtrlAltDel(ctx)
+		if err := m.sendCtrlAltDel(ctx); err != nil {
+			return err
+		}
 	} else {
-		return m.StopVMM()
+		if err := m.StopVMM(); err != nil {
+			return err
+		}
 	}
+	rootfs := filepath.Join(
+		m.Cfg.JailerCfg.ChrootBaseDir,
+		filepath.Base(m.Cfg.JailerCfg.ExecFile),
+		m.Cfg.JailerCfg.ID,
+		rootfsFolderName,
+	)
+	for _, drive := range m.Cfg.Drives {
+		hostPath := StringValue(drive.PathOnHost)
+		driveFileName := filepath.Base(hostPath)
+		rootfsPath := filepath.Join(rootfs, driveFileName)
+		if err := unix.Unmount(rootfsPath, 0); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Wait will wait until the firecracker process has finished.  Wait is safe to

--- a/machine.go
+++ b/machine.go
@@ -35,7 +35,6 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/sys/unix"
 
 	log "github.com/sirupsen/logrus"
 
@@ -470,20 +469,6 @@ func (m *Machine) Shutdown(ctx context.Context) error {
 	} else {
 		if err := m.StopVMM(); err != nil {
 			return err
-		}
-	}
-	rootfs := filepath.Join(
-		m.Cfg.JailerCfg.ChrootBaseDir,
-		filepath.Base(m.Cfg.JailerCfg.ExecFile),
-		m.Cfg.JailerCfg.ID,
-		rootfsFolderName,
-	)
-	for _, drive := range m.Cfg.Drives {
-		hostPath := StringValue(drive.PathOnHost)
-		driveFileName := filepath.Base(hostPath)
-		rootfsPath := filepath.Join(rootfs, driveFileName)
-		if err := unix.Unmount(rootfsPath, 0); err != nil {
-			return fmt.Errorf("failed to unmount %s: %v", rootfsPath, err)
 		}
 	}
 	return nil

--- a/machine.go
+++ b/machine.go
@@ -483,7 +483,7 @@ func (m *Machine) Shutdown(ctx context.Context) error {
 		driveFileName := filepath.Base(hostPath)
 		rootfsPath := filepath.Join(rootfs, driveFileName)
 		if err := unix.Unmount(rootfsPath, 0); err != nil {
-			return err
+			return fmt.Errorf("failed to unmount %s: %v", rootfsPath, err)
 		}
 	}
 	return nil

--- a/opts.go
+++ b/opts.go
@@ -73,6 +73,9 @@ func WithSnapshot(memFilePath, snapshotPath string, opts ...WithSnapshotOpt) Opt
 
 		m.Handlers.Validation = loadSnapshotValidationHandlerList
 		m.Handlers.FcInit = loadSnapshotHandlerList
+		if m.Cfg.JailerCfg != nil {
+			m.Cfg.JailerCfg.ChrootStrategy.AdaptHandlers(&m.Handlers)
+		}
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This links the memory and snapshot files into the root of the jail and fixes an issue where `WithSnapshots` overrides the injected `LinkFilesHandler`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
