### PR TITLE
Add dependabot configuration for GitHub Actions packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: gomod
-    directory: /
+  # Automatic upgrade for Go modules.
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
-      interval: daily
+      interval: "daily"
 
+  # Automatic upgrade for GitHub Actions packages.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
*Issue #, if available:*
N/A

GitHub Actions workflows are showing deprecation warnings which can be resolved by dependabot automation.

*Description of changes:*
This change adds GitHub Actions packages update automation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
