### PR TITLE
fix TestLogAndMetrics

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -457,8 +457,8 @@ func TestLogAndMetrics(t *testing.T) {
 		quiet    bool
 	}{
 		{logLevel: "", quiet: false},
-		{logLevel: "Info", quiet: false},
-		{logLevel: "Error", quiet: true},
+		{logLevel: "Info", quiet: true},
+		{logLevel: "Error", quiet: false},
 	}
 	for _, test := range tests {
 		t.Run(test.logLevel, func(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
TestLogAndMetrics/Error  currently fails with Error
```
=== CONT  TestLogAndMetrics/Error
    machine_test.go:469:
        	Error Trace:	/local/home/buildkite-agent/builds/ip-10-0-0-92-30/firecracker-microvm/firecracker-go-sdk-amd/machine_test.go:469
        	Error:      	Expect "" to match "^Running Firecracker v\d+\.\d+[\.-]"
        	Test:       	TestLogAndMetrics/Error
```
After looking into the code, looks like there has been a recent change in Firecracker to fix the logger behavior. https://github.com/firecracker-microvm/firecracker/pull/4171. After the change, the log-level passed to Firecracker is respected, so when we pass "Error" loglevel, the info message does not get printed


*Description of changes:*
The "Running Firecracker v\d+\.\d+[\.-]" log should be written to fc.logs when loglevel is set to INFO




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
