### PR TITLE
Revert "fix TestLogAndMetrics"

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -457,8 +457,8 @@ func TestLogAndMetrics(t *testing.T) {
 		quiet    bool
 	}{
 		{logLevel: "", quiet: false},
-		{logLevel: "Info", quiet: true},
-		{logLevel: "Error", quiet: false},
+		{logLevel: "Info", quiet: false},
+		{logLevel: "Error", quiet: true},
 	}
 	for _, test := range tests {
 		t.Run(test.logLevel, func(t *testing.T) {


### PR DESCRIPTION
This reverts commit d9c024234199e3cb155f5bc97a59a7ce5fbba20f.

*Issue #, if available:* The above PR requires more work since latest Firecracker logging configuration has been updated and it no longer produces similar results as v1.4.1. Reverting the above change, since we need to redo the test entirely

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
