### PR TITLE
Update go path on buildkite host after go1.21 update

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 env:
-  PATH: "/usr/lib/go-1.18/bin:/usr/bin"
+  PATH: "/usr/local/bin:/usr/bin"
   FC_TEST_DATA_PATH: "/tmp/buildkite_build_${BUILDKITE_BUILD_NUMBER}_testdata"
 
 steps:


### PR DESCRIPTION
*Issue #, if available:*

`go version` checks failing on buildkite host after recent go1.21 update. go binary path has changed from `/usr/lib/go-*` to `/usr/local/bin`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
