### PR TITLE
Skip LogAndMetricis test when running on firecracker version >1.4.x

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -450,6 +450,9 @@ func TestStartVMM(t *testing.T) {
 }
 
 func TestLogAndMetrics(t *testing.T) {
+	if skipLogAndMetricsTest() {
+		t.Skip()
+	}
 	fctesting.RequiresKVM(t)
 
 	tests := []struct {
@@ -478,6 +481,21 @@ func TestLogAndMetrics(t *testing.T) {
 			assert.Contains(t, out, ":"+logLevel+"]")
 		})
 	}
+}
+
+func skipLogAndMetricsTest() bool {
+	// Firecracker logging behavior has changed after
+	// https://github.com/firecracker-microvm/firecracker/pull/4047
+	// This includes default log level being changed from WARN to INFO
+	// TODO: Update this test once firecracker version is upgraded to >v1.5.0
+	version, err := getFirecrackerVersion()
+	if err != nil {
+		return true
+	}
+	// match version 1.4.x
+	pattern := `^1\.4\.\d+$`
+	match, _ := regexp.MatchString(pattern, version)
+	return !match
 }
 
 func testLogAndMetrics(t *testing.T, logLevel string) string {


### PR DESCRIPTION
*Issue #, if available:*
Firecracker logging behavior has changed after v1.5.0. This causes CI test failures when running against latest Firecracker version.
*Description of changes:*
 Update test to skip if not running against v1.4.x

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
