### PR TITLE
Pass `--level` through `jailer` if set

### DIFF
--- a/jailer.go
+++ b/jailer.go
@@ -339,6 +339,10 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
 	fcArgs := seccompArgs(cfg)
 	fcArgs = append(fcArgs, "--api-sock", machineSocketPath)
 
+	if cfg.LogLevel != "" {
+		fcArgs = append(fcArgs, "--level", cfg.LogLevel)
+	}
+
 	builder := NewJailerCommandBuilder().
 		WithID(cfg.JailerCfg.ID).
 		WithUID(*cfg.JailerCfg.UID).


### PR DESCRIPTION
*Issue #, if available:* https://github.com/firecracker-microvm/firecracker-go-sdk/issues/534

*Description of changes:* In upgrading Firecracker, I noticed a handful of new log lines regarding invocations of the Firecracker API. I've traced them down to [logging the API call](https://github.com/firecracker-microvm/firecracker/blob/e641bfb584a8a029c9585d96da16d6195354fca5/src/firecracker/src/api_server/parsed_request.rs#L69), and [a series of successful request messages](https://github.com/search?q=repo%3Afirecracker-microvm%2Ffirecracker%20%22The%20request%20was%20executed%20successfully%22&type=code). To reduce the amount of log output from Firecracker, I tried adjusting the log level to `Warning`, but it had no effect as the `jailer` and the SDK do not seem to respect the setting if no path or fifo is used. This change changes the `jailer` so that it will propagate the level through to the binary's `--level` flag if set.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
