### PR TITLE
Revert "Pass firecracker log level through jailer"

### DIFF
--- a/jailer.go
+++ b/jailer.go
@@ -339,10 +339,6 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
 	fcArgs := seccompArgs(cfg)
 	fcArgs = append(fcArgs, "--api-sock", machineSocketPath)
 
-	if cfg.LogLevel != "" {
-		fcArgs = append(fcArgs, "--level", cfg.LogLevel)
-	}
-
 	builder := NewJailerCommandBuilder().
 		WithID(cfg.JailerCfg.ID).
 		WithUID(*cfg.JailerCfg.UID).


### PR DESCRIPTION
This reverts commit fe672947d6eeda2d2c99ff1379a766cbc25e0fee.

*Issue #, if available:*
Passing `--log-level` without passing `log-path` [is not supported](https://github.com/firecracker-microvm/firecracker/blob/v1.4.1/src/firecracker/src/main.rs#L182-L186) in firecracker v1.4.1. The above PR breaks that behavior resulting in CI failures.  This behavior has been changed since firecracker v1.5.0, so we should be able to make the change once we update this SDK to support v1.5.0 api. But for now the behavior should remain consistent with v1.4.1 api. 

Adding a separate issue #580 580 to track the addition of this change once we upgrade go-sdk to support firecracker v1.5.0 


@gudmundur @austinvazquez 

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
