### PR TITLE
Fix get firecracker version test

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -644,7 +644,7 @@ func testCreateMachine(ctx context.Context, t *testing.T, m *Machine) {
 }
 
 func parseVersionFromStdout(stdout []byte) (string, error) {
-	pattern := regexp.MustCompile(`Firecracker v(?P<version>[0-9]\.[0-9]\.[0-9]-?.*)`)
+	pattern := regexp.MustCompile(`Firecracker v(?P<version>[0-9]+\.[0-9]+\.[0-9]+-?.*)`)
 	groupNames := pattern.SubexpNames()
 	matches := pattern.FindStringSubmatch(string(stdout))
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Firecracker mainline is now on v1.10.0-dev, but our version regex only allowed a single digit for each part of the version. This allows 1+ digits for each part.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
