### PR TITLE
Do not overwrite handlers in LoadSnapshot

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -315,22 +315,21 @@ var defaultFcInitHandlerList = HandlerList{}.Append(
 	ConfigMmdsHandler,
 )
 
-var loadSnapshotHandlerList = HandlerList{}.Append(
-	SetupNetworkHandler,
-	StartVMMHandler,
-	CreateLogFilesHandler,
-	BootstrapLoggingHandler,
-	LoadSnapshotHandler,
-	AddVsocksHandler,
-)
+// When the machine starts, these handlers cannot run
+// if we plan to load a snapshot. As these handlers are
+// included in defaultFcInitHandlerList, we must remove them
+// if WithSnapshot() has been specified.
+var loadSnapshotRemoveHandlerList = []Handler{
+	SetupKernelArgsHandler,
+	CreateMachineHandler,
+	CreateBootSourceHandler,
+	AttachDrivesHandler,
+	CreateNetworkInterfacesHandler,
+	ConfigMmdsHandler,
+}
 
 var defaultValidationHandlerList = HandlerList{}.Append(
 	NetworkConfigValidationHandler,
-)
-
-var loadSnapshotValidationHandlerList = HandlerList{}.Append(
-	NetworkConfigValidationHandler,
-	LoadSnapshotConfigValidationHandler,
 )
 
 var defaultHandlers = Handlers{

--- a/opts.go
+++ b/opts.go
@@ -71,9 +71,17 @@ func WithSnapshot(memFilePath, snapshotPath string, opts ...WithSnapshotOpt) Opt
 			opt(&m.Cfg.Snapshot)
 		}
 
-		m.Handlers.Validation = loadSnapshotValidationHandlerList
-		m.Handlers.FcInit = loadSnapshotHandlerList
+		m.Handlers.Validation = m.Handlers.Validation.Append(LoadSnapshotConfigValidationHandler)
+		m.Handlers.FcInit = modifyHandlersForLoadSnapshot(m.Handlers.FcInit)
 	}
+}
+
+func modifyHandlersForLoadSnapshot(l HandlerList) HandlerList {
+	for _, h := range loadSnapshotRemoveHandlerList {
+		l = l.Remove(h.Name)
+	}
+	l = l.Append(LoadSnapshotHandler)
+	return l
 }
 
 // WithMemoryBackend sets the memory backend to the given type, using the given


### PR DESCRIPTION
*Issue #, if available:*
Closes #627

*Description of changes:*
As LoadSnapshot requires only a subset of the default handlers, it was implemented by assigning the FcInit handlers to a smaller list of handlers. However, this meant that it would overwrite the FcInit handlers given by the jailer. This PR fixes this behavior by just removing the unnecessary handlers, instead of overwriting them entirely.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
