### PR TITLE
Fix kernelArgs not parsing kernel 'init' parameter with command line arguments

### DIFF
--- a/kernelargs_test.go
+++ b/kernelargs_test.go
@@ -24,19 +24,22 @@ func TestKernelArgsSerder(t *testing.T) {
 	fooVal := "bar"
 	booVal := "far"
 	dooVal := "a=silly=val"
+	initVal := "/bin/sh -- -c \"echo hello\""
 	emptyVal := ""
 
-	argsString := fmt.Sprintf("foo=%s blah doo=%s huh=%s bleh duh=%s boo=%s",
+	argsString := fmt.Sprintf("foo=%s blah doo=%s huh=%s bleh duh=%s boo=%s init=%s",
 		fooVal,
 		dooVal,
 		emptyVal,
 		emptyVal,
 		booVal,
+		initVal,
 	)
 
 	expectedParsedArgs := kernelArgs(map[string]*string{
 		"foo":  &fooVal,
 		"doo":  &dooVal,
+		"init": &initVal,
 		"blah": nil,
 		"huh":  &emptyVal,
 		"bleh": nil,
@@ -45,6 +48,8 @@ func TestKernelArgsSerder(t *testing.T) {
 	})
 
 	actualParsedArgs := parseKernelArgs(argsString)
+	fmt.Printf("%v\n", actualParsedArgs)
+	fmt.Printf("%v\n", expectedParsedArgs)
 	require.Equal(t, expectedParsedArgs, actualParsedArgs, "kernel args parsed to unexpected values")
 
 	reparsedArgs := parseKernelArgs(actualParsedArgs.String())


### PR DESCRIPTION
*Description of changes:*

kernelArgs fails while parsing "init" kernel parameters with extra command line arguments. For example the following kernel args gets incorrectly parsed:

```
console=ttyS0 reboot=k panic=1 pci=off init=/bin/sh -- -c "echo hello"
```

This PR follows the requirements for command line arguments stated at: https://docs.kernel.org/admin-guide/kernel-parameters.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
