### PR TITLE
Bump Go min version to Go 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ['1.21', '1.22', '1.23']
+        go: ['1.23', '1.24']
         os: ['ubuntu-22.04']
       fail-fast: false
     name: ${{ matrix.os }} / Go ${{ matrix.go }}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please see [HACKING](HACKING.md)
 Building
 ---
 
-This library requires Go 1.18 or later and Go modules to build.  A Makefile is provided
+This library requires Go 1.23 or later and Go modules to build.  A Makefile is provided
 for convenience, but is not required.  When using the Makefile, you can pass
 additional flags to the Go compiler via the `EXTRAGOARGS` make variable.
 

--- a/doc.go
+++ b/doc.go
@@ -18,7 +18,7 @@ Firecracker is an open-source virtualization technology that is purpose-built
 for creating and managing secure, multi-tenant containers and functions-based
 services.  See https://firecracker-microvm.github.io/ for more details.
 
-This library requires Go 1.18 or later and can be used with Go modules.
+This library requires Go 1.23 or later and can be used with Go modules.
 
 BUG(aws): There are some Firecracker features that are not yet supported by the
 SDK.  These are tracked as GitHub issues with the firecracker-feature label:

--- a/examples/cmd/snapshotting/go.mod
+++ b/examples/cmd/snapshotting/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21
+go 1.23
 
 require (
 	github.com/firecracker-microvm/firecracker-go-sdk v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/firecracker-microvm/firecracker-go-sdk
 
-go 1.21
+go 1.23
 
 require (
 	github.com/containerd/fifo v1.1.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change updates the minimum required Go version to Go 1.23 to unblock dependabot PRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
