### PR TITLE
Fix BuildKite CI for download Go errors

### DIFF
--- a/examples/cmd/snapshotting/go.mod
+++ b/examples/cmd/snapshotting/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/firecracker-microvm/firecracker-go-sdk v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/firecracker-microvm/firecracker-go-sdk
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/containerd/fifo v1.1.0


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:*

*Description of changes:*
This change documents the Go min version as Go 1.23.0 to resolve BuildKite CI errors when downloading the Go toolchain.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
